### PR TITLE
feat: 상품 등록 페이지 UI 구현

### DIFF
--- a/src/components/common/CustomButton.stories.tsx
+++ b/src/components/common/CustomButton.stories.tsx
@@ -1,0 +1,21 @@
+import { Meta, StoryObj } from "@storybook/react";
+import CustomButton from "./CustomButton";
+
+const meta: Meta<typeof CustomButton> = {
+  title: "components/common/CustomButton",
+  component: CustomButton,
+  tags: ["autodocs"],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof CustomButton>;
+
+export const CustomButtonTest: Story = {
+  parameters: {
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/design/hY76phjdEqYFydjyfkajtW/Retail?node-id=465-202&t=MnPdSfKrSa6KuTGV-4",
+    },
+  },
+};

--- a/src/components/common/CustomButton.tsx
+++ b/src/components/common/CustomButton.tsx
@@ -1,0 +1,16 @@
+type Props = {
+  label: string;
+  cssOption: string;
+  onClick: () => void;
+};
+
+export default function CustomButton({ label, cssOption, onClick }: Props) {
+  return (
+    <button
+      className={`rounded-full px-[20px] py-[10px] text-center cursor-pointer ${cssOption}`}
+      onClick={onClick}
+    >
+      {label}
+    </button>
+  );
+}

--- a/src/components/common/CustomInput.tsx
+++ b/src/components/common/CustomInput.tsx
@@ -8,34 +8,51 @@ import React from "react";
 
 type Props = {
   inputType?: "password";
+  isOnlyNumber?: boolean;
   title: string;
-  titleType: "ko" | "en";
+  titleType?: "ko" | "en";
   onChange: (_e: React.ChangeEvent<HTMLInputElement>) => void;
   placeholder: string;
-  width: number;
-  height: number;
+  width?: number;
+  height?: number;
 };
 
 export default function CustomInput({
   inputType,
+  isOnlyNumber = false,
   title,
-  titleType,
+  titleType = "ko",
   onChange,
   placeholder,
-  width,
-  height,
+  width = 500,
+  height = 60,
 }: Props) {
+  const numberHandler = (e: React.FormEvent<HTMLInputElement>) => {
+    if (isOnlyNumber) {
+      const input = e.currentTarget;
+      const numericValue = input.value.replace(/[^0-9]/g, "");
+
+      if (input.value !== numericValue) {
+        input.value = numericValue;
+
+        const event = new Event("input", { bubbles: true });
+        input.dispatchEvent(event);
+      }
+    }
+  };
+
   return (
     <div className="flex flex-col gap-2">
       <p lang={titleType} className="text-[20px] font-semibold">
         {title}
       </p>
       <input
-        className="border rounded-[50px] pl-[24px] border-gray05 bg-gray02 placeholder:text-gray07 text-gray10 text-[19px] transition-all duration-200 focus:border-gray09 focus:outline-none"
+        className="border rounded-full pl-[24px] border-gray05 bg-gray02 placeholder:text-gray07 text-gray10 text-[19px] transition-all duration-200 focus:border-gray09 focus:outline-none"
         style={{ width: `${width}px`, height: `${height}px` }}
         type={inputType || "text"}
         placeholder={placeholder}
         onChange={onChange}
+        onInput={isOnlyNumber ? numberHandler : undefined}
       />
     </div>
   );

--- a/src/components/common/Modal.tsx
+++ b/src/components/common/Modal.tsx
@@ -99,7 +99,7 @@ export default function Modal({
         <p className="mt-2 text-[24px] text-center text-gray10">{content}</p>
 
         {/* 버튼 2개 */}
-        <div className="justify-center absolute bottom-[46px] left-1/2 -translate-x-1/2 flex gap-[66px]">
+        <div className="justify-center absolute bottom-[46px] left-1/2 -translate-x-1/2 flex gap-[66px] w-full">
           {onCancel && (
             <button
               onClick={onCancel}

--- a/src/components/common/NavBar.tsx
+++ b/src/components/common/NavBar.tsx
@@ -9,7 +9,7 @@ export default function NavBar() {
   const navigate = useNavigate();
 
   return (
-    <div className="fixed z-100 top-0 w-screen flex h-[80px] items-center justify-between px-10 border-b border-gray04">
+    <div className="fixed z-100 top-0 w-screen flex h-[80px] items-center justify-between px-10 border-b border-gray04 bg-gray01">
       <div className="flex items-center gap-[50px]">
         <img
           src={logoImage}

--- a/src/components/layouts/GlobalLayout.tsx
+++ b/src/components/layouts/GlobalLayout.tsx
@@ -6,9 +6,11 @@ export default function GlobalLayout() {
   return (
     <div className="box-border">
       <NavBar />
-      <CustomErrorBoundary>
-        <Outlet />
-      </CustomErrorBoundary>
+      <div className="mt-[80px]">
+        <CustomErrorBoundary>
+          <Outlet />
+        </CustomErrorBoundary>
+      </div>
     </div>
   );
 }

--- a/src/constants/NavigationItems.ts
+++ b/src/constants/NavigationItems.ts
@@ -5,7 +5,7 @@ export const NavigationItems = [
   },
   {
     title: "팝업관리",
-    url: "/popup",
+    url: "/popup-list",
   },
   {
     title: "상품관리",

--- a/src/pages/itemAddPage/ItemAddPage.tsx
+++ b/src/pages/itemAddPage/ItemAddPage.tsx
@@ -4,6 +4,7 @@ import ItemAddInputs from "./views/ItemAddInputs";
 import TestImage from "@/assets/webps/onBoarding/test.png";
 import Modal from "@/components/common/Modal";
 import bin from "@/assets/webps/common/bin.webp";
+import check from "@/assets/webps/common/check.webp";
 import { useNavigate } from "react-router-dom";
 
 export default function ItemAddPage() {
@@ -86,8 +87,8 @@ export default function ItemAddPage() {
         setIsOpen={setIsAlertModalOpen}
         content="상품 등록을 취소하시겠어요?"
         image={bin}
-        confirmText="취소"
-        cancelText="이전"
+        confirmText="취소하기"
+        cancelText="돌아가기"
         onConfirm={() => navigate("/products")}
         onCancel={() => setIsAlertModalOpen(false)}
       />
@@ -96,7 +97,7 @@ export default function ItemAddPage() {
         isOpen={isSaveModalOpen}
         setIsOpen={setIsSaveModalOpen}
         content="상품이 등록되었습니다"
-        image={bin}
+        image={check}
         confirmText="확인"
         onConfirm={handleSaveConfirmBtn}
       />

--- a/src/pages/itemAddPage/ItemAddPage.tsx
+++ b/src/pages/itemAddPage/ItemAddPage.tsx
@@ -34,12 +34,12 @@ export default function ItemAddPage() {
       <div className="flex gap-[14px] mt-[46px] mr-[80px] justify-end">
         <CustomButton
           label="취소"
-          cssOption="bg-gray03 text-gray08 text-[20px] w-[76px] h-[46px] hover:opacity-50"
+          cssOption="bg-gray03 text-gray08 text-[20px] hover:opacity-50"
           onClick={handleSave}
         />
         <CustomButton
           label="등록"
-          cssOption="bg-gray10 text-gray01 text-[20px] w-[76px] h-[46px] hover:opacity-50"
+          cssOption="bg-gray10 text-gray01 text-[20px] hover:opacity-50"
           onClick={handleSave}
         />
       </div>

--- a/src/pages/itemAddPage/ItemAddPage.tsx
+++ b/src/pages/itemAddPage/ItemAddPage.tsx
@@ -2,12 +2,32 @@ import CustomButton from "@/components/common/CustomButton";
 import React, { useState } from "react";
 import ItemAddInputs from "./views/ItemAddInputs";
 import TestImage from "@/assets/webps/onBoarding/test.png";
+import Modal from "@/components/common/Modal";
+import bin from "@/assets/webps/common/bin.webp";
+import { useNavigate } from "react-router-dom";
 
 export default function ItemAddPage() {
   const [itemTitle, setItemTitle] = useState<string>("");
   const [itemQuantity, setItemQuantity] = useState<number>(0);
   const [itemPrice, setItemPrice] = useState<number>(0);
   const [itemLocation, setItemLocation] = useState<string>("");
+  const [isAlertModalOpen, setIsAlertModalOpen] = useState<boolean>(false);
+  const [isSaveModalOpen, setIsSaveModalOpen] = useState<boolean>(false);
+  const navigate = useNavigate();
+
+  const handleCancel = () => {
+    setIsAlertModalOpen(true);
+  };
+
+  const handleSave = () => {
+    setIsSaveModalOpen(true);
+    return itemTitle && itemQuantity && itemPrice && itemLocation;
+  };
+
+  const handleSaveConfirmBtn = () => {
+    setIsSaveModalOpen(false);
+    navigate("/products");
+  };
 
   const handleTitle = (e: React.ChangeEvent<HTMLInputElement>) => {
     setItemTitle(e.target.value);
@@ -25,17 +45,13 @@ export default function ItemAddPage() {
     setItemLocation(e.target.value);
   };
 
-  const handleSave = () => {
-    return itemTitle && itemQuantity && itemPrice && itemLocation;
-  };
-
   return (
     <div className="flex flex-col">
       <div className="flex gap-[14px] mt-[46px] mr-[80px] justify-end">
         <CustomButton
           label="취소"
-          cssOption="bg-gray03 text-gray08 text-[20px] hover:opacity-50"
-          onClick={handleSave}
+          cssOption="bg-gray01 border border-gray05 text-gray09 text-[20px] hover:bg-gray02 transition"
+          onClick={handleCancel}
         />
         <CustomButton
           label="등록"
@@ -65,6 +81,25 @@ export default function ItemAddPage() {
           handleLocation={handleLocation}
         />
       </div>
+      <Modal
+        isOpen={isAlertModalOpen}
+        setIsOpen={setIsAlertModalOpen}
+        content="상품 등록을 취소하시겠어요?"
+        image={bin}
+        confirmText="취소"
+        cancelText="이전"
+        onConfirm={() => navigate("/products")}
+        onCancel={() => setIsAlertModalOpen(false)}
+      />
+
+      <Modal
+        isOpen={isSaveModalOpen}
+        setIsOpen={setIsSaveModalOpen}
+        content="상품이 등록되었습니다"
+        image={bin}
+        confirmText="확인"
+        onConfirm={handleSaveConfirmBtn}
+      />
     </div>
   );
 }

--- a/src/pages/itemAddPage/ItemAddPage.tsx
+++ b/src/pages/itemAddPage/ItemAddPage.tsx
@@ -1,0 +1,70 @@
+import CustomButton from "@/components/common/CustomButton";
+import React, { useState } from "react";
+import ItemAddInputs from "./views/ItemAddInputs";
+import TestImage from "@/assets/webps/onBoarding/test.png";
+
+export default function ItemAddPage() {
+  const [itemTitle, setItemTitle] = useState<string>("");
+  const [itemQuantity, setItemQuantity] = useState<number>(0);
+  const [itemPrice, setItemPrice] = useState<number>(0);
+  const [itemLocation, setItemLocation] = useState<string>("");
+
+  const handleTitle = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setItemTitle(e.target.value);
+  };
+
+  const handleQuantity = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setItemQuantity(Number(e.target.value));
+  };
+
+  const handlePrice = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setItemPrice(Number(e.target.value));
+  };
+
+  const handleLocation = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setItemLocation(e.target.value);
+  };
+
+  const handleSave = () => {
+    return itemTitle && itemQuantity && itemPrice && itemLocation;
+  };
+
+  return (
+    <div className="flex flex-col">
+      <div className="flex gap-[14px] mt-[46px] mr-[80px] justify-end">
+        <CustomButton
+          label="취소"
+          cssOption="bg-gray03 text-gray08 text-[20px] w-[76px] h-[46px] hover:opacity-50"
+          onClick={handleSave}
+        />
+        <CustomButton
+          label="등록"
+          cssOption="bg-gray10 text-gray01 text-[20px] w-[76px] h-[46px] hover:opacity-50"
+          onClick={handleSave}
+        />
+      </div>
+      <div className="absolute left-[50%] top-[50%] transform -translate-x-1/2 -translate-y-1/2 flex justify-center items-center gap-[53px]">
+        <div className="relative w-[400px] h-[400px]">
+          <img
+            src={TestImage}
+            alt="상품 이미지"
+            width={400}
+            className="w-full h-full object-cover"
+          />
+          <input
+            type="file"
+            accept="image/*"
+            onChange={() => {}}
+            className="absolute inset-0 w-full h-full opacity-0 cursor-pointer z-10"
+          />
+        </div>
+        <ItemAddInputs
+          handleTitle={handleTitle}
+          handleQuantity={handleQuantity}
+          handlePrice={handlePrice}
+          handleLocation={handleLocation}
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/pages/itemAddPage/ItemAddPage.tsx
+++ b/src/pages/itemAddPage/ItemAddPage.tsx
@@ -65,7 +65,7 @@ export default function ItemAddPage() {
             src={TestImage}
             alt="상품 이미지"
             width={400}
-            className="w-full h-full object-cover"
+            className="w-full h-full object-cover rounded-[20px]"
           />
           <input
             type="file"

--- a/src/pages/itemAddPage/views/ItemAddInputs.tsx
+++ b/src/pages/itemAddPage/views/ItemAddInputs.tsx
@@ -1,0 +1,43 @@
+import CustomInput from "@/components/common/CustomInput";
+import React from "react";
+
+type Props = {
+  handleTitle: (_e: React.ChangeEvent<HTMLInputElement>) => void;
+  handleQuantity: (_e: React.ChangeEvent<HTMLInputElement>) => void;
+  handlePrice: (_e: React.ChangeEvent<HTMLInputElement>) => void;
+  handleLocation: (_e: React.ChangeEvent<HTMLInputElement>) => void;
+};
+
+export default function ItemAddInputs({
+  handleTitle,
+  handleQuantity,
+  handlePrice,
+  handleLocation,
+}: Props) {
+  return (
+    <div className="flex flex-col gap-[30px]">
+      <CustomInput
+        title="상품명"
+        placeholder="상품명을 입력해주세요"
+        onChange={handleTitle}
+      />
+      <CustomInput
+        isOnlyNumber={true}
+        title="가격"
+        placeholder="가격을 입력해주세요"
+        onChange={handlePrice}
+      />
+      <CustomInput
+        isOnlyNumber={true}
+        title="수량"
+        placeholder="상품 수량을 입력해주세요"
+        onChange={handleQuantity}
+      />
+      <CustomInput
+        title="로케이션"
+        placeholder="상품 로케이션을 입력해주세요"
+        onChange={handleLocation}
+      />
+    </div>
+  );
+}

--- a/src/pages/itemListPage/ItemListPage.tsx
+++ b/src/pages/itemListPage/ItemListPage.tsx
@@ -1,0 +1,11 @@
+import { useNavigate } from "react-router-dom";
+
+export default function ItemListPage() {
+  const navigate = useNavigate();
+  return (
+    <div>
+      아이템 리스트 페이지
+      <button onClick={() => navigate("./create")}>등록 페이지 이동</button>
+    </div>
+  );
+}

--- a/src/pages/onBoarding/OnBoarding.tsx
+++ b/src/pages/onBoarding/OnBoarding.tsx
@@ -81,7 +81,9 @@ export default function OnBorading() {
           </div>
         </div>
       </div>
-      <OnBoardingLogin />
+      <div className="py-[54px]">
+        <OnBoardingLogin />
+      </div>
     </div>
   );
 }

--- a/src/pages/onBoarding/views/OnBoardingLogin.tsx
+++ b/src/pages/onBoarding/views/OnBoardingLogin.tsx
@@ -10,7 +10,7 @@ export default function OnBoradingLogin() {
   const handleLogin = () => {};
 
   return (
-    <div className="flex flex-col my-[50px] gap-[34px] items-center">
+    <div className="flex flex-col gap-[34px] items-center">
       <div className="flex flex-col gap-4">
         <CustomInput
           title="Email"

--- a/src/pages/onBoarding/views/OnBoardingLogin.tsx
+++ b/src/pages/onBoarding/views/OnBoardingLogin.tsx
@@ -36,7 +36,7 @@ export default function OnBoradingLogin() {
       </div>
       <button
         lang="en"
-        className={`w-[500px] h-[60px] text-[22px] font-medium rounded-[50px] ${isActive ? "bg-main07 cursor-pointer" : "bg-main04"} text-gray02`}
+        className={`w-[500px] h-[60px] text-[22px] font-medium rounded-full ${isActive ? "bg-main07 cursor-pointer" : "bg-main04"} text-gray02`}
         disabled={!isActive}
         onClick={handleLogin}
       >

--- a/src/router/Router.tsx
+++ b/src/router/Router.tsx
@@ -1,5 +1,6 @@
 import GlobalLayout from "@/components/layouts/GlobalLayout";
 import DashBoard from "@/pages/dashboard/DashBoard";
+import ItemAddPage from "@/pages/itemAddPage/ItemAddPage";
 import OnBorading from "@/pages/onBoarding/OnBoarding";
 import PopUpList from "@/pages/popUpList/PopUpList";
 import { createBrowserRouter } from "react-router-dom";
@@ -12,6 +13,10 @@ export const Router = createBrowserRouter([
       {
         path: "/dashboard",
         element: <DashBoard />,
+      },
+      {
+        path: "/item-add",
+        element: <ItemAddPage />,
       },
     ],
   },

--- a/src/router/Router.tsx
+++ b/src/router/Router.tsx
@@ -1,6 +1,7 @@
 import GlobalLayout from "@/components/layouts/GlobalLayout";
 import DashBoard from "@/pages/dashboard/DashBoard";
 import ItemAddPage from "@/pages/itemAddPage/ItemAddPage";
+import ItemListPage from "@/pages/itemListPage/ItemListPage";
 import OnBorading from "@/pages/onBoarding/OnBoarding";
 import PopUpList from "@/pages/popUpList/PopUpList";
 import { createBrowserRouter } from "react-router-dom";
@@ -15,8 +16,12 @@ export const Router = createBrowserRouter([
         element: <DashBoard />,
       },
       {
-        path: "/item-add",
+        path: "/products/create",
         element: <ItemAddPage />,
+      },
+      {
+        path: "/products",
+        element: <ItemListPage />,
       },
     ],
   },


### PR DESCRIPTION
## 🌱 관련 이슈

- [LCR-21]

---

## 📌 작업 내용 및 특이사항

- 아이템 등록 페이지 UI 구현
- 공통 컴포넌트 기능 수정
```html
// CustomInput.tsx
<div className="flex flex-col gap-2">
  <p lang={titleType} className="text-[20px] font-semibold">
    {title}
  </p>
  <input
    className="border rounded-full pl-[24px] border-gray05 bg-gray02 placeholder:text-gray07 text-gray10 text-[19px] transition-all duration-200 focus:border-gray09 focus:outline-none"
    style={{ width: `${width}px`, height: `${height}px` }}
    type={inputType || "text"}
    placeholder={placeholder}
    onChange={onChange}
    onInput={isOnlyNumber ? numberHandler : undefined}
  />
</div>
```
숫자만 취급해야하는 인풋의 경우, 다른 외부 입력을 받지 않도록 수정했습니다.
- CustomButton.tsx 구현
- 버튼 클릭시 라우팅까지 임시로 구현해놨습니다.
- 네비게이션바 스타일링 일부 수정했습니다 (배경색 지정)
- onBoarding 로그인 부분 패딩 추가했습니다.

---

## 📚 참고사항
### 기본 UI
<img width="1337" alt="image" src="https://github.com/user-attachments/assets/a70ec732-734c-42c2-a367-5de12979d365" />

### 이미지 클릭시 선택 가능합니다 
- 기능은 추후에 개발해야합니다.
<img width="1347" alt="image" src="https://github.com/user-attachments/assets/132b0735-d162-4477-9aab-c92df013d6c3" />

### 취소 Modal
- 취소 클릭시 버튼 네임은 `뒤로가기`, `취소하기` 입니다.
![image](https://github.com/user-attachments/assets/aafc6d96-702b-4ec2-a004-26558a9d59b2)


### 등록 Modal
- 상품 등록 모달입니다. 
![image](https://github.com/user-attachments/assets/768be347-cd2d-43a2-bbd3-b16478c2715c)

[LCR-21]: https://lgcns-retail.atlassian.net/browse/LCR-21?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ