### PR TITLE
feat: 대시보드 설문지 분석 UI 구현

### DIFF
--- a/chromatic.config.json
+++ b/chromatic.config.json
@@ -1,0 +1,5 @@
+{
+  "onlyChanged": true,
+  "projectId": "Project:68145e4fb508a397a4f41502",
+  "zip": true
+}

--- a/src/mocks/handlers/dashboard/Questionnaire.ts
+++ b/src/mocks/handlers/dashboard/Questionnaire.ts
@@ -34,6 +34,21 @@ export const QuestionnaireDatas: QuestionnaireType[] = [
         numOfRespondents: 380,
         ratio: 30,
       },
+      {
+        title: "사인회",
+        numOfRespondents: 290,
+        ratio: 23,
+      },
+      {
+        title: "팬티켓팅",
+        numOfRespondents: 180,
+        ratio: 14,
+      },
+      {
+        title: "음악방송",
+        numOfRespondents: 150,
+        ratio: 12,
+      },
     ],
   },
   {

--- a/src/mocks/handlers/dashboard/Questionnaire.ts
+++ b/src/mocks/handlers/dashboard/Questionnaire.ts
@@ -1,0 +1,94 @@
+import { QuestionnaireType } from "@/types/QuestionnaireType";
+
+export const QuestionnaireDatas: QuestionnaireType[] = [
+  {
+    questionNumber: 1,
+    contents: [
+      {
+        title: "포토 카드",
+        numOfRespondents: 400,
+        ratio: 32,
+      },
+      {
+        title: "앨범 (CD)",
+        numOfRespondents: 350,
+        ratio: 28,
+      },
+      {
+        title: "디지털 음원",
+        numOfRespondents: 200,
+        ratio: 16,
+      },
+    ],
+  },
+  {
+    questionNumber: 2,
+    contents: [
+      {
+        title: "콘서트",
+        numOfRespondents: 520,
+        ratio: 42,
+      },
+      {
+        title: "팬미팅",
+        numOfRespondents: 380,
+        ratio: 30,
+      },
+    ],
+  },
+  {
+    questionNumber: 3,
+    contents: [
+      {
+        title: "티셔츠",
+        numOfRespondents: 300,
+        ratio: 24,
+      },
+      {
+        title: "모자",
+        numOfRespondents: 250,
+        ratio: 20,
+      },
+      {
+        title: "키링",
+        numOfRespondents: 420,
+        ratio: 34,
+      },
+    ],
+  },
+  {
+    questionNumber: 4,
+    contents: [
+      {
+        title: "SNS 활동",
+        numOfRespondents: 680,
+        ratio: 54,
+      },
+      {
+        title: "유튜브 컨텐츠",
+        numOfRespondents: 590,
+        ratio: 47,
+      },
+    ],
+  },
+  {
+    questionNumber: 5,
+    contents: [
+      {
+        title: "리얼리티 프로그램",
+        numOfRespondents: 480,
+        ratio: 38,
+      },
+      {
+        title: "예능 프로그램",
+        numOfRespondents: 520,
+        ratio: 42,
+      },
+      {
+        title: "라디오 출연",
+        numOfRespondents: 210,
+        ratio: 17,
+      },
+    ],
+  },
+];

--- a/src/mocks/handlers/dashboard/VisitorDatas.ts
+++ b/src/mocks/handlers/dashboard/VisitorDatas.ts
@@ -1,4 +1,3 @@
-///Users/yeongseo/Documents/GitHub/FE-Manager/src/mocks/handlers/dashboard/VisitorDatas.ts
 export const VisitorGenderData = [
   { name: "남성", value: 1200 },
   { name: "여성", value: 800 },

--- a/src/mocks/handlers/dashboard/VisitorDatas.ts
+++ b/src/mocks/handlers/dashboard/VisitorDatas.ts
@@ -1,3 +1,4 @@
+///Users/yeongseo/Documents/GitHub/FE-Manager/src/mocks/handlers/dashboard/VisitorDatas.ts
 export const VisitorGenderData = [
   { name: "남성", value: 1200 },
   { name: "여성", value: 800 },

--- a/src/pages/dashboard/DashBoard.tsx
+++ b/src/pages/dashboard/DashBoard.tsx
@@ -4,6 +4,7 @@ import DashBoardReservation from "@/pages/dashboard/views/DashBoardReservation";
 import BestProduct from "./views/BestProduct";
 import DashBoardConversionRate from "@/pages/dashboard/views/DashBoardConversionRate";
 import DashBoardVisitor from "./views/DashBoardVisitor";
+import DashBoardQuestionnaire from "./views/DashBoardQuestionnaire";
 
 export default function DashBoard() {
   return (
@@ -17,7 +18,9 @@ export default function DashBoard() {
         <DashBoardReservation />
         <DashBoardCustomerTransaction />
       </div>
-      <DashBoardConversionRate />
+      <div>
+        <DashBoardQuestionnaire />
+      </div>
     </div>
   );
 }

--- a/src/pages/dashboard/DashBoard.tsx
+++ b/src/pages/dashboard/DashBoard.tsx
@@ -18,9 +18,8 @@ export default function DashBoard() {
         <DashBoardReservation />
         <DashBoardCustomerTransaction />
       </div>
-      <div>
-        <DashBoardQuestionnaire />
-      </div>
+      <DashBoardConversionRate />
+      <DashBoardQuestionnaire />
     </div>
   );
 }

--- a/src/pages/dashboard/views/DashBoardQuestionnaire.stories.tsx
+++ b/src/pages/dashboard/views/DashBoardQuestionnaire.stories.tsx
@@ -1,0 +1,24 @@
+import { Meta, StoryObj } from "@storybook/react";
+import DashBoardQuestionnaire from "./DashBoardQuestionnaire";
+
+const meta: Meta<typeof DashBoardQuestionnaire> = {
+  title: "pages/dashboard/views/DashBoardQuestionnaire",
+  component: DashBoardQuestionnaire,
+  tags: ["autodocs"],
+  //   argTypes: {
+  //     onClick: { action: "clicked" },
+  //   },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof DashBoardQuestionnaire>;
+
+export const DashBoardQuestionnaireTest: Story = {
+  parameters: {
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/design/hY76phjdEqYFydjyfkajtW/Retail?node-id=465-202&t=MnPdSfKrSa6KuTGV-4",
+    },
+  },
+};

--- a/src/pages/dashboard/views/DashBoardQuestionnaire.tsx
+++ b/src/pages/dashboard/views/DashBoardQuestionnaire.tsx
@@ -4,14 +4,21 @@ import { useState } from "react";
 import { Questions } from "@/constants/popUpCreate/Questions";
 import { QuestionnaireDatas } from "@/mocks/handlers/dashboard/Questionnaire";
 import { QuestionnaireType } from "@/types/QuestionnaireType";
+import { Cell, Pie, PieChart, Tooltip, TooltipProps } from "recharts";
+import CustomTooltip from "@/components/common/CustomTooltip";
 
 const options = ["1번 문항", "2번 문항", "3번 문항", "4번 문항"];
+const SIZE = 300;
+const RADIUS = 150;
+const colorSet = ["#ff7caf", "#cacafb", "#a2c9ff", "#c5efe8", "#ffd0a1"];
 
+// "1번 문항" 과 같은 텍스트에서 번호를 추출하여 선택된 QuestionNumber를 리턴합니다.
 const findQuestionNumber = (selected: string) => {
   const regex = /[0-9]+/;
   return Number(selected.match(regex));
 };
 
+// 각 문항마다 전체 응시자 수를 계산합니다.
 const findQuestionTotal = (questionnaireData: QuestionnaireType) => {
   const totalRespondents = questionnaireData.contents.reduce((sum, content) => {
     return sum + content.numOfRespondents;
@@ -26,12 +33,14 @@ export default function DashBoardQuestionnaire() {
     setSelectedQuestion(selected);
   };
 
+  // 클라이언트에서 관리하는 상수 데이터를 재사용합니다. (DB에서 title을 저장하지 않도록 하기 위함)
   const matchQuestion = (selected: string): string => {
     const questionNumber = findQuestionNumber(selected);
     const target = Questions.find(q => q.questionNumber === questionNumber);
     return `Q${target?.questionNumber}. ${target?.title}`;
   };
 
+  // API로부터 호출하여 받아온 데이터에서 questionNumber에 맞는 답변 데이터를 추출하여 반환합니다.
   const matchQA = (selected: string): QuestionnaireType & { total: number } => {
     const questionNumber = findQuestionNumber(selected);
     const found = QuestionnaireDatas.find(
@@ -66,13 +75,14 @@ export default function DashBoardQuestionnaire() {
           {matchQuestion(selectedQuestion)}
         </p>
         <div className="flex">
-          <div className="w-[1240px] h-[490px] bg-gray01 mt-[40px] rounded-[40px] px-[40px] py-[30px] flex">
-            <div className="flex flex-col gap-[20px]">
+          <div className="w-[1240px] h-[490px] bg-gray01 mt-[40px] rounded-[40px] px-[40px] py-[30px] flex justify-between">
+            {/** 왼쪽 - 설문 답변 리스트 */}
+            <div className="flex flex-col gap-[20px] w-[458px]">
               {matched.contents.map((content, idx) => {
                 return (
                   <div key={idx}>
-                    <div className="rounded-[20px] bg-gray02 text-[20px] flex items-center h-[72px] w-[458px]">
-                      <span className="mr-4 w-[64px] h-full flex items-center justify-center rounded-l-[20px] bg-blue-100 text-[32px]">
+                    <div className="rounded-[20px] bg-gray02 text-[20px] flex items-center h-[72px] w-full">
+                      <span className="mr-4 w-[64px] h-full flex items-center justify-center rounded-l-[20px] text-[32px] bg-blue02">
                         {idx + 1}
                       </span>
                       <p className="text-[20px] ml-[30px]">{content.title}</p>
@@ -81,8 +91,79 @@ export default function DashBoardQuestionnaire() {
                 );
               })}
             </div>
-            <div>
-              <p>전체 응시자 수 : {matched.total}</p>
+            {/** 오른쪽 - 파이 차트 */}
+            <div className="flex flex-col items-end h-full">
+              <p className="text-[20px] font-medium text-gray08">
+                전체 응시자 수: {matched.total}명
+              </p>
+              <div className="flex justify-center gap-[80px] items-center">
+                <PieChart width={SIZE} height={SIZE}>
+                  <Tooltip
+                    cursor={{ fill: "transparent" }}
+                    content={(props: TooltipProps<number, string>) => {
+                      if (
+                        !props.active ||
+                        !props.payload ||
+                        props.payload.length === 0
+                      )
+                        return null;
+
+                      const targetPayload = props.payload[0].payload;
+                      return (
+                        <CustomTooltip
+                          active={props.active}
+                          payload={[
+                            {
+                              value: targetPayload.numOfRespondents,
+                              name: targetPayload.title,
+                              dataKey: "numOfRespondents",
+                            },
+                          ]}
+                          label={targetPayload.title}
+                          unitSuffix="명"
+                          highlightColor={
+                            colorSet[
+                              props.payload[0].dataKey === "numOfRespondents"
+                                ? matched.contents.findIndex(
+                                    c => c.title === targetPayload.title,
+                                  ) % colorSet.length
+                                : 0
+                            ]
+                          }
+                        />
+                      );
+                    }}
+                  />
+
+                  <Pie
+                    data={matched.contents}
+                    innerRadius={0}
+                    outerRadius={RADIUS}
+                    dataKey="numOfRespondents"
+                    nameKey="title"
+                    cx="50%"
+                    cy="50%"
+                    paddingAngle={0}
+                  >
+                    {matched.contents.map((_, idx) => (
+                      <Cell key={idx} fill={colorSet[idx % colorSet.length]} />
+                    ))}
+                  </Pie>
+                </PieChart>
+                <div className="grid grid-cols-2 gap-x-6 gap-y-4 h-[100px]">
+                  {matched.contents.map((_, idx) => (
+                    <div key={idx} className="flex items-center gap-2">
+                      <span
+                        className="w-[38px] h-[18px] rounded-[8px]"
+                        style={{
+                          backgroundColor: colorSet[idx % colorSet.length],
+                        }}
+                      />
+                      <span>{idx + 1}번</span>
+                    </div>
+                  ))}
+                </div>
+              </div>
             </div>
           </div>
         </div>

--- a/src/pages/dashboard/views/DashBoardQuestionnaire.tsx
+++ b/src/pages/dashboard/views/DashBoardQuestionnaire.tsx
@@ -1,0 +1,92 @@
+import { DropdownFilter } from "@/components/common/DropdownFilter";
+import DashBoardTitle from "./DashBoardTitle";
+import { useState } from "react";
+import { Questions } from "@/constants/popUpCreate/Questions";
+import { QuestionnaireDatas } from "@/mocks/handlers/dashboard/Questionnaire";
+import { QuestionnaireType } from "@/types/QuestionnaireType";
+
+const options = ["1번 문항", "2번 문항", "3번 문항", "4번 문항"];
+
+const findQuestionNumber = (selected: string) => {
+  const regex = /[0-9]+/;
+  return Number(selected.match(regex));
+};
+
+const findQuestionTotal = (questionnaireData: QuestionnaireType) => {
+  const totalRespondents = questionnaireData.contents.reduce((sum, content) => {
+    return sum + content.numOfRespondents;
+  }, 0);
+  return totalRespondents;
+};
+
+export default function DashBoardQuestionnaire() {
+  const [selectedQuestion, setSelectedQuestion] = useState<string>(options[0]);
+
+  const handleQuestion = (selected: string) => {
+    setSelectedQuestion(selected);
+  };
+
+  const matchQuestion = (selected: string): string => {
+    const questionNumber = findQuestionNumber(selected);
+    const target = Questions.find(q => q.questionNumber === questionNumber);
+    return `Q${target?.questionNumber}. ${target?.title}`;
+  };
+
+  const matchQA = (selected: string): QuestionnaireType & { total: number } => {
+    const questionNumber = findQuestionNumber(selected);
+    const found = QuestionnaireDatas.find(
+      q => q.questionNumber === questionNumber,
+    );
+
+    if (!found) {
+      throw new Error(
+        "API 요청 결과와 QuestionNumber가 매칭되지 않습니다. 요청 Response를 다시 확인해주세요",
+      );
+    }
+
+    const total = findQuestionTotal(found);
+
+    return { ...found, total };
+  };
+
+  const matched = matchQA(selectedQuestion);
+
+  return (
+    <div className="flex flex-col">
+      <div className="flex gap-[20px]">
+        <DashBoardTitle title="설문지 분석" />
+        <DropdownFilter
+          value={selectedQuestion}
+          options={options}
+          onChange={handleQuestion}
+        />
+      </div>
+      <div className="w-[1360px] h-[662px] bg-gray02 rounded-[50px] px-[60px] py-[45px]">
+        <p className="font-semibold text-[36px]">
+          {matchQuestion(selectedQuestion)}
+        </p>
+        <div className="flex">
+          <div className="w-[1240px] h-[490px] bg-gray01 mt-[40px] rounded-[40px] px-[40px] py-[30px] flex">
+            <div className="flex flex-col gap-[20px]">
+              {matched.contents.map((content, idx) => {
+                return (
+                  <div key={idx}>
+                    <div className="rounded-[20px] bg-gray02 text-[20px] flex items-center h-[72px] w-[458px]">
+                      <span className="mr-4 w-[64px] h-full flex items-center justify-center rounded-l-[20px] bg-blue-100 text-[32px]">
+                        {idx + 1}
+                      </span>
+                      <p className="text-[20px] ml-[30px]">{content.title}</p>
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+            <div>
+              <p>전체 응시자 수 : {matched.total}</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/popUpCreate/PopUpCreate.tsx
+++ b/src/pages/popUpCreate/PopUpCreate.tsx
@@ -282,7 +282,7 @@ export default function PopUpCreate() {
       <Modal
         isOpen={isAlertModalOpen}
         setIsOpen={setIsAlertModalOpen}
-        content="상품 등록을 취소하시겠어요?"
+        content="팝업 등록을 취소하시겠어요?"
         image={bin}
         confirmText="취소하기"
         cancelText="돌아가기"
@@ -293,7 +293,7 @@ export default function PopUpCreate() {
       <Modal
         isOpen={isSaveModalOpen}
         setIsOpen={setIsSaveModalOpen}
-        content="상품이 등록되었습니다"
+        content="팝업이 등록되었습니다"
         image={check}
         confirmText="확인"
         onConfirm={handleSaveConfirmBtn}

--- a/src/types/QuestionnaireType.ts
+++ b/src/types/QuestionnaireType.ts
@@ -1,0 +1,8 @@
+export type QuestionnaireType = {
+  questionNumber: number;
+  contents: {
+    title: string;
+    numOfRespondents: number;
+    ratio: number;
+  }[];
+};


### PR DESCRIPTION
## 🌱 관련 이슈

- [LCR-58]

---

## 📌 작업 내용 및 특이사항

- 대쉬보드 설문지 UI 구현했습니다. (DashBoardQuestionnaire.tsx)
- 피그마에는 차트에 들어가는 색상이 4개까지 밖에 없어서 `#ffd0a1` (노란색 계열) 색상 임의로 추가했습니다.
- 공통 컴포넌트 CustomTooltip과 DropdownFilter를 사용했습니다.
- 나중에 코드 리팩토링을 진행한다면, 차트에 사용되는 색깔 배열을 constants로 뺄 수 있을 것 같습니다.

---

## 📚 참고사항
![ezgif-444a734e492662](https://github.com/user-attachments/assets/ab1778b8-327e-4f92-8a19-67e7d816ac0d)



[LCR-58]: https://lgcns-retail.atlassian.net/browse/LCR-58?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ