### PR TITLE
feat: 팝업 리스트 조회 api 연동

### DIFF
--- a/src/apis/PopUpListApi.ts
+++ b/src/apis/PopUpListApi.ts
@@ -1,0 +1,11 @@
+import { api } from "@/apis/config/Axios";
+
+export const getPopUpList = async () => {
+  const response = await api.get("/popups");
+  return response.data;
+};
+
+export const deletePopUpList = async (popupId: number) => {
+  const response = await api.delete(`/popups/${popupId}`);
+  return response.data;
+};


### PR DESCRIPTION
## 🌱 관련 이슈

- [LCR-96]

---

## 📌 작업 내용 및 특이사항

- feat: 팝업 리스트 페이지 조회 기능 구현
팝업 리스트 API 연동을 위해 먼저 src/apis/PopUpList.ts 파일에 GET /popups 요청을 처리하는` getPopUpList `함수를 추가했습니다. 

이 함수를 기반으로 React-Query 훅인 `usePopUpListApi`를 구현했으며, 해당 훅은 queryKey로 ["popupList"]를 사용하고, queryFn에서 getPopUpList의 결과(res.data)를 반환하도록 구성했습니다.

또한 네트워크 오류 시 최대 1회 재시도하도록 설정했습니다.

Mock 서버 연동을 위해 MSW(Mock Service Worker) 핸들러도 등록했는데, src/mocks/handlers/popUpList/PopUpCards.ts 파일에 `http.get("/popups")` 핸들러를 추가하여, 초기 더미 데이터가 담긴 popups 변수를 응답 바디의 data 필드로 리턴하도록 했습니다. 

이 핸들러는 기존의 ProductHandlers 등 다른 mock 핸들러와 혼동되지 않도록 별도의 경로와 파일로 분리했습니다.

마지막으로, API 응답과 컴포넌트 간의 타입 안정성을 위해 PopUpListResponse 타입을 선언하고 popupId, name, imageUrl 필드를 명시적으로 정의했습니다.

## 📚 참고사항

- /popup → /popups로 경로가 변경
- React-Query가 캐시된 데이터를 관리하므로, 추후 삭제·수정 기능 구현 시 invalidateQueries 또는 refetch 필요

https://github.com/user-attachments/assets/023fb11e-3068-4c6b-a6c1-77bab6b61265






[LCR-96]: https://lgcns-retail.atlassian.net/browse/LCR-96?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ