### PR TITLE
feat: 팝업 전역 상태관리 기능 구현

### DIFF
--- a/src/pages/popUpListPage/views/PopUpCard.tsx
+++ b/src/pages/popUpListPage/views/PopUpCard.tsx
@@ -1,11 +1,26 @@
 import xWhite from "@/assets/webps/popUpList/x-white.webp";
+import { usePopUpReadStore } from "@/stores/usePopUpReadStore";
 import { GetPopUpReadResponse } from "@/types/api/ApiResponseType";
+import { useNavigate } from "react-router-dom";
 
 type Props = GetPopUpReadResponse & {
   onDeleteClick: () => void;
 };
 
-export default function PopUpCard({ name, imageUrl, onDeleteClick }: Props) {
+export default function PopUpCard({
+  popupId,
+  name,
+  imageUrl,
+  onDeleteClick,
+}: Props) {
+  const setPopUp = usePopUpReadStore(state => state.setPopUp);
+  const navigate = useNavigate();
+
+  const handleSelect = () => {
+    setPopUp({ popupId, name, imageUrl });
+    navigate("/dashboard");
+  };
+
   return (
     <>
       <div className="w-[286px] flex justify-center">
@@ -33,6 +48,7 @@ export default function PopUpCard({ name, imageUrl, onDeleteClick }: Props) {
         </div>
       </div>
       <span
+        onClick={handleSelect}
         lang="en"
         className="cursor-pointer w-[286px] break-words block text-center justify-center text-[34px] mt-[22px]"
       >

--- a/src/stores/useAuthStore.ts
+++ b/src/stores/useAuthStore.ts
@@ -1,12 +1,12 @@
 import { create } from "zustand";
 import { createJSONStorage, persist } from "zustand/middleware";
 
-interface AuthState {
+type AuthState = {
   accessToken: string | null;
   isLogin: boolean;
   setLogin: (_token: string) => void;
   setLogout: () => void;
-}
+};
 
 export const useAuthStore = create<AuthState>()(
   persist(

--- a/src/stores/usePopUpReadStore.ts
+++ b/src/stores/usePopUpReadStore.ts
@@ -1,0 +1,27 @@
+import { GetPopUpReadResponse } from "@/types/api/ApiResponseType";
+import { create } from "zustand";
+import { createJSONStorage, persist } from "zustand/middleware";
+
+type PopUpReadStoreType = GetPopUpReadResponse & {
+  setPopUp: (_popup: GetPopUpReadResponse) => void;
+};
+
+export const usePopUpReadStore = create<PopUpReadStoreType>()(
+  persist(
+    set => ({
+      popupId: 0,
+      name: "",
+      imageUrl: "",
+      setPopUp: ({ popupId, name, imageUrl }) =>
+        set({ popupId, name, imageUrl }),
+    }),
+    {
+      name: "popup-storage",
+      storage: createJSONStorage(() => localStorage),
+      partialize: state => ({
+        popupId: state.popupId,
+        name: state.name,
+      }),
+    },
+  ),
+);


### PR DESCRIPTION
## 🌱 관련 이슈

- [LCR-108]
---

## 📌 작업 내용 및 특이사항

- zustand로 popUp 정보(popUpId, name, imageUrl) 전역 상태 관리하였습니다.
- localStorage에 (popUpId, name) persist 하였습니다.
- 팝업 리스트에서 xx번 팝업 클릭하면 handleSelect 함수가 실행되면서 usePopUpReadStore의 setPopUp을 실행해 xx번 팝업에 대한 정보를 popUp 상태로 저장합니다. 그 이후 /dashboard 페이지로 라우팅됩니다.

---

## 📚 참고사항
팝업 리스트에서 9번째 팝업 클릭 > 네트워크 탭 > 로컬 스토리지
<img width="621" alt="image" src="https://github.com/user-attachments/assets/2d0aeda7-16b4-4945-afc7-8f53fb19470d" />



[LCR-108]: https://lgcns-retail.atlassian.net/browse/LCR-108?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ