### PR TITLE
feat: 예약자 수 조회 기능 구현

### DIFF
--- a/src/apis/DashBoardApi.ts
+++ b/src/apis/DashBoardApi.ts
@@ -2,6 +2,7 @@ import {
   ApiResponse,
   GetAvgPurchaseResponse,
   EntrantsResponse,
+  ReservationsResponse,
 } from "@/types/api/ApiResponseType";
 import { api } from "./config/Axios";
 import { usePopUpReadStore } from "@/stores/usePopUpReadStore";
@@ -14,8 +15,15 @@ export const getAvgPurchase = async (): ApiResponse<GetAvgPurchaseResponse> => {
   return response.data;
 };
 
-export const getTodayReservation = async (): ApiResponse<EntrantsResponse> => {
+export const getTodayEntrants = async (): ApiResponse<EntrantsResponse> => {
   const popupId = usePopUpReadStore.getState().popupId;
   const response = await api.get(`/popups/${popupId}/dashboard/entrants`);
   return response.data;
 };
+
+export const getTodayReservations =
+  async (): ApiResponse<ReservationsResponse> => {
+    const popupId = usePopUpReadStore.getState().popupId;
+    const res = await api.get(`/popups/${popupId}/dashboard/reservations`);
+    return res.data;
+  };

--- a/src/hooks/api/useDashboardApi.ts
+++ b/src/hooks/api/useDashboardApi.ts
@@ -1,5 +1,9 @@
 import { useQuery } from "@tanstack/react-query";
-import { getAvgPurchase, getTodayReservation } from "@/apis/DashBoardApi";
+import {
+  getAvgPurchase,
+  getTodayEntrants,
+  getTodayReservations,
+} from "@/apis/DashBoardApi";
 
 export const useAvgPurchaseApi = () => {
   const { data, isError, isLoading } = useQuery({
@@ -15,9 +19,21 @@ export const useAvgPurchaseApi = () => {
 
 export const useTodayEntrantsApi = () => {
   const { data, isError, isLoading } = useQuery({
+    queryKey: ["todayEntrants", "dashboard"],
+    queryFn: async () => {
+      const res = await getTodayEntrants();
+      return res.data;
+    },
+  });
+
+  return { data, isError, isLoading };
+};
+
+export const useTodayReservationsApi = () => {
+  const { data, isError, isLoading } = useQuery({
     queryKey: ["todayReservation", "dashboard"],
     queryFn: async () => {
-      const res = await getTodayReservation();
+      const res = await getTodayReservations();
       return res.data;
     },
   });

--- a/src/mocks/browser.ts
+++ b/src/mocks/browser.ts
@@ -3,9 +3,12 @@ import { AuthHandlers } from "@/mocks/handlers/onBoarding/Auth.handlers";
 import { DashboardHandlers } from "./handlers/dashboard/CustomerTransactionDatas";
 import { PopUpCreateHandlers } from "@/mocks/handlers/popUpCreate/PopUpCreate.handlers";
 import { popUpListReadHandlers } from "@/mocks/handlers/popUpListRead/popUpListRead.handlers";
-import { EntrantsHandlers } from "./handlers/dashboard/ReservationDatas";
-import { ItemListHandlers } from "./handlers/itemList/ItemList.handlers";
 import { ItemCreateHandlers } from "./handlers/itemCreate/ItemCreate.handlers";
+import {
+  EntrantsHandlers,
+  ReservationsHandlers,
+} from "./handlers/dashboard/ReservationDatas";
+import { ItemListHandlers } from "./handlers/itemList/ItemList.handlers";
 
 export const handlers = [
   ...AuthHandlers,
@@ -15,6 +18,7 @@ export const handlers = [
   ...ItemListHandlers,
   ...DashboardHandlers,
   ...EntrantsHandlers,
+  ...ReservationsHandlers,
 ];
 
 export const worker = setupWorker(...handlers);

--- a/src/mocks/handlers/dashboard/CustomerTransactionDatas.ts
+++ b/src/mocks/handlers/dashboard/CustomerTransactionDatas.ts
@@ -19,3 +19,6 @@ export const DashboardHandlers = [
     );
   }),
 ];
+
+
+

--- a/src/mocks/handlers/dashboard/CustomerTransactionDatas.ts
+++ b/src/mocks/handlers/dashboard/CustomerTransactionDatas.ts
@@ -19,6 +19,3 @@ export const DashboardHandlers = [
     );
   }),
 ];
-
-
-

--- a/src/mocks/handlers/dashboard/ReservationDatas.ts
+++ b/src/mocks/handlers/dashboard/ReservationDatas.ts
@@ -1,8 +1,11 @@
-import { EntrantsResponse } from "@/types/api/ApiResponseType";
-import { ReservationChartType } from "@/types/ReservationType";
+import {
+  EntrantsResponse,
+  ReservationChartResponse,
+  ReservationsResponse,
+} from "@/types/api/ApiResponseType";
 import { http, HttpResponse } from "msw";
 
-export const ReservationChartDatas: ReservationChartType[] = [
+export const ReservationChartDatas: ReservationChartResponse[] = [
   { day: "월", value: 220 },
   { day: "화", value: 210 },
   { day: "수", value: 90 },
@@ -16,6 +19,11 @@ export const TodayEntrantsDatas: EntrantsResponse = {
   enteredCount: 180,
 };
 
+export const TodayReservationDatas: ReservationsResponse = {
+  reservedCount: 200,
+  chart: ReservationChartDatas,
+};
+
 export const EntrantsHandlers = [
   http.get("/popups/:popupId/dashboard/entrants", () => {
     return HttpResponse.json(
@@ -23,6 +31,20 @@ export const EntrantsHandlers = [
         success: true,
         status: 200,
         data: TodayEntrantsDatas,
+        timestamp: new Date().toISOString(),
+      },
+      { status: 200 },
+    );
+  }),
+];
+
+export const ReservationsHandlers = [
+  http.get("/popups/:popupId/dashboard/reservations", () => {
+    return HttpResponse.json(
+      {
+        success: true,
+        status: 200,
+        data: TodayReservationDatas,
         timestamp: new Date().toISOString(),
       },
       { status: 200 },

--- a/src/pages/dashboardPage/views/DashBoardReservation.tsx
+++ b/src/pages/dashboardPage/views/DashBoardReservation.tsx
@@ -2,22 +2,25 @@ import DashBoardTitle from "@/pages/dashboardPage/views/DashBoardTitle";
 import checkCalendar from "@/assets/webps/dashboard/check-calendar.webp";
 import { CountCard } from "@/pages/dashboardPage/views/CountCard";
 import ReservationByDayChart from "@/pages/dashboardPage/views/ReservationByDayChart";
-import { useTodayEntrantsApi } from "@/hooks/api/useDashboardApi";
+import {
+  useTodayEntrantsApi,
+  useTodayReservationsApi,
+} from "@/hooks/api/useDashboardApi";
 
 export default function DashBoardReservation() {
-  const { data } = useTodayEntrantsApi();
+  const { data: entrantsData } = useTodayEntrantsApi();
+  const { data: reservationsData } = useTodayReservationsApi();
 
   return (
     <div className="w-[906px] flex-col">
       <DashBoardTitle title="예약 분석" />
-      {data && (
+      {entrantsData && reservationsData && (
         <div className="w-[1360px] h-[394px] flex gap-10">
           <div className="w-[314px] flex flex-col justify-between">
             <CountCard
               title="예약자 수"
               bgCSS="bg-main01"
-              // value={data.reservedCount.toLocaleString()}
-              value="100"
+              value={reservationsData.reservedCount.toLocaleString()}
               valueCSS="text-main04 text-[64px]"
               unit="명"
               unitCSS="text-main04 text-[40px]"
@@ -25,7 +28,7 @@ export default function DashBoardReservation() {
             <CountCard
               title="입장자 수"
               bgCSS="bg-purple02"
-              value={data.enteredCount.toLocaleString()}
+              value={entrantsData.enteredCount.toLocaleString()}
               valueCSS="text-purple06 text-[64px]"
               unit="명"
               unitCSS="text-purple06 text-[40px]"
@@ -45,7 +48,7 @@ export default function DashBoardReservation() {
                 요일별 예약자 수
               </span>
             </div>
-            <ReservationByDayChart />
+            <ReservationByDayChart data={reservationsData.chart} />
           </div>
         </div>
       )}

--- a/src/pages/dashboardPage/views/ReservationByDayChart.tsx
+++ b/src/pages/dashboardPage/views/ReservationByDayChart.tsx
@@ -13,7 +13,7 @@ import {
 
 type Props = {
   data: ReservationChartResponse[];
-}
+};
 
 export default function ReservationByDayChart({ data }: Props) {
   const coloredData = reservationColorMapper(data);

--- a/src/pages/dashboardPage/views/ReservationByDayChart.tsx
+++ b/src/pages/dashboardPage/views/ReservationByDayChart.tsx
@@ -1,5 +1,5 @@
 import CustomTooltip from "@/components/common/CustomTooltip";
-import { ReservationChartDatas } from "@/mocks/handlers/dashboard/ReservationDatas";
+import { ReservationChartResponse } from "@/types/api/ApiResponseType";
 import { reservationColorMapper } from "@/utils/ReservationColorMapper";
 import {
   BarChart,
@@ -11,10 +11,14 @@ import {
   Cell,
 } from "recharts";
 
-export default function ReservationByDayChart() {
-  const coloredData = reservationColorMapper(ReservationChartDatas);
+interface Props {
+  data: ReservationChartResponse[];
+}
+
+export default function ReservationByDayChart({ data }: Props) {
+  const coloredData = reservationColorMapper(data);
   // max값 기준 y축 눈금 100 단위로 만들기
-  const maxValue = Math.max(...ReservationChartDatas.map(d => d.value)); // value 중 가장 큰 수
+  const maxValue = Math.max(...data.map(d => d.value)); // value 중 가장 큰 수
   const roundedMax = Math.ceil(maxValue / 100) * 100; // 100 단위 올림
   const ticks = [];
 

--- a/src/pages/dashboardPage/views/ReservationByDayChart.tsx
+++ b/src/pages/dashboardPage/views/ReservationByDayChart.tsx
@@ -11,7 +11,7 @@ import {
   Cell,
 } from "recharts";
 
-interface Props {
+type Props = {
   data: ReservationChartResponse[];
 }
 

--- a/src/types/ReservationType.ts
+++ b/src/types/ReservationType.ts
@@ -1,4 +1,0 @@
-export type ReservationChartType = {
-  day: string;
-  value: number;
-};

--- a/src/types/api/ApiResponseType.ts
+++ b/src/types/api/ApiResponseType.ts
@@ -44,3 +44,13 @@ export type GetAvgPurchaseResponse = {
 export type EntrantsResponse = {
   enteredCount: number;
 };
+
+export type ReservationsResponse = {
+  reservedCount: number;
+  chart: ReservationChartResponse[];
+};
+
+export type ReservationChartResponse = {
+  day: string;
+  value: number;
+};

--- a/src/utils/ReservationColorMapper.ts
+++ b/src/utils/ReservationColorMapper.ts
@@ -1,5 +1,5 @@
 import { Colors } from "@/constants/dashboard/Colors";
-import { ReservationChartType } from "@/types/ReservationType";
+import { ReservationChartResponse } from "@/types/api/ApiResponseType";
 
 /**
  * 요일별 예약자 수 데이터에 value 기준으로 색상을 매핑합니다.
@@ -8,7 +8,7 @@ import { ReservationChartType } from "@/types/ReservationType";
  */
 
 // ⭐️ value 기준 오름차순으로 color 매칭시키기 ⭐️
-export function reservationColorMapper(data: ReservationChartType[]) {
+export function reservationColorMapper(data: ReservationChartResponse[]) {
   // 1. value 기준 오름차순 정렬
   const sortedData = [...data].sort((a, b) => a.value - b.value);
 


### PR DESCRIPTION
## 🌱 관련 이슈

- [LCR-117]

---

## 📌 작업 내용 및 특이사항
- 예약자 수 조회 API 연결하였습니다.
- 타입 정의: `ReservationsResponse`(예약자 수 + 차트 데이터) 추가
- API 구현: `getTodayReservations()` 작성
- 훅 추가: useTodayReservationsApi로 reservedCount & chart 조회
- MSW 핸들러: ReservationsHandlers로 목업 응답 제공
- 컴포넌트 연동: `DashBoardReservation.tsx`에서 reservedCount, chart를 `ReservationByDayChart`에 전달
- 차트 리팩토링: `ReservationByDayChart.tsx`를 `data` prop 기반 렌더링으로 수정


---

## 📚 참고사항

<img width="481" alt="image" src="https://github.com/user-attachments/assets/6c854ee2-ba08-41aa-ac9f-c6e6c7089f3c" />



[LCR-117]: https://lgcns-retail.atlassian.net/browse/LCR-117?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ