### PR TITLE
feat: 대시보드 혼잡도 분석 조회 기능 구현

### DIFF
--- a/src/apis/DashBoardApi.ts
+++ b/src/apis/DashBoardApi.ts
@@ -4,10 +4,17 @@ import {
   EntrantsResponse,
   ReservationsResponse,
   GetBestItemsResponse,
+  GetCongestionResponse,
 } from "@/types/api/ApiResponseType";
 import { api } from "./config/Axios";
 import { usePopUpReadStore } from "@/stores/usePopUpReadStore";
 import { GetBestItemsRequest } from "@/types/api/ApiRequestType";
+
+export const getCongestion = async (): ApiResponse<GetCongestionResponse> => {
+  const popupId = usePopUpReadStore.getState().popupId;
+  const response = await api.get(`/popups/${popupId}/dashboard/congestion`);
+  return response.data;
+};
 
 export const getAvgPurchase = async (): ApiResponse<GetAvgPurchaseResponse> => {
   const popupId = usePopUpReadStore.getState().popupId;

--- a/src/hooks/api/useDashboardApi.ts
+++ b/src/hooks/api/useDashboardApi.ts
@@ -4,8 +4,21 @@ import {
   getBestItems,
   getTodayEntrants,
   getTodayReservations,
+  getCongestion,
 } from "@/apis/DashBoardApi";
 import { GetBestItemsRequest } from "@/types/api/ApiRequestType";
+
+export const useCongestionApi = () => {
+  const { data, isError, isLoading } = useQuery({
+    queryKey: ["congestion", "dashboard"],
+    queryFn: async () => {
+      const res = await getCongestion();
+      return res.data;
+    },
+  });
+
+  return { data, isError, isLoading };
+};
 
 export const useAvgPurchaseApi = () => {
   const { data, isError, isLoading } = useQuery({

--- a/src/mocks/browser.ts
+++ b/src/mocks/browser.ts
@@ -12,6 +12,7 @@ import { StockNotificationListHandlers } from "@/mocks/handlers/noticeModal/Stoc
 import { ItemListHandlers } from "./handlers/itemList/ItemList.handlers";
 import { LogoutHandlers } from "./Logout.handlers";
 import { BestItemsHandlers } from "./handlers/dashboard/BestItems";
+import { CongestionReadHandlers } from "@/mocks/handlers/dashboard/CongestionRead.handlers";
 
 export const handlers = [
   ...AuthHandlers,
@@ -25,6 +26,7 @@ export const handlers = [
   ...StockNotificationListHandlers,
   ...LogoutHandlers,
   ...BestItemsHandlers,
+  ...CongestionReadHandlers,
 ];
 
 export const worker = setupWorker(...handlers);

--- a/src/mocks/browser.ts
+++ b/src/mocks/browser.ts
@@ -13,6 +13,7 @@ import { ItemListHandlers } from "./handlers/itemList/ItemList.handlers";
 import { LogoutHandlers } from "./Logout.handlers";
 import { BestItemsHandlers } from "./handlers/dashboard/BestItems";
 import { CongestionReadHandlers } from "@/mocks/handlers/dashboard/CongestionRead.handlers";
+import { ItemCreateHandlers } from "./handlers/itemCreate/ItemCreate.handlers";
 
 export const handlers = [
   ...AuthHandlers,

--- a/src/mocks/browser.ts
+++ b/src/mocks/browser.ts
@@ -13,7 +13,6 @@ import { ItemListHandlers } from "./handlers/itemList/ItemList.handlers";
 import { LogoutHandlers } from "./Logout.handlers";
 import { BestItemsHandlers } from "./handlers/dashboard/BestItems";
 import { CongestionReadHandlers } from "@/mocks/handlers/dashboard/CongestionRead.handlers";
-import { ItemCreateHandlers } from "./handlers/itemCreate/ItemCreate.handlers";
 
 export const handlers = [
   ...AuthHandlers,

--- a/src/mocks/handlers/dashboard/CongestionRead.handlers.ts
+++ b/src/mocks/handlers/dashboard/CongestionRead.handlers.ts
@@ -1,6 +1,7 @@
-import { CongestionType } from "@/types/CongestionType";
+import { GetCongestionResponse } from "@/types/api/ApiResponseType";
+import { http, HttpResponse } from "msw";
 
-export const CongestionDatas: CongestionType = {
+export const congestionList: GetCongestionResponse = {
   mon: [
     { time: 6, value: 5 },
     { time: 8, value: 10 },
@@ -86,3 +87,17 @@ export const CongestionDatas: CongestionType = {
     { time: 24, value: 8 },
   ],
 };
+
+export const CongestionReadHandlers = [
+  http.get("/popups/:popupId/dashboard/congestion", () => {
+    return HttpResponse.json(
+      {
+        success: true,
+        status: 200,
+        data: congestionList,
+        timestamp: new Date().toISOString(),
+      },
+      { status: 200 },
+    );
+  }),
+];

--- a/src/pages/dashboardPage/views/CongestionChart.tsx
+++ b/src/pages/dashboardPage/views/CongestionChart.tsx
@@ -1,8 +1,8 @@
 import CustomBlurDot from "@/components/common/CustomBlurDot";
 import CustomCursor from "@/components/common/CustomCursor";
 import CustomTooltip from "@/components/common/CustomTooltip";
-import { CongestionDatas } from "@/mocks/handlers/dashboard/ConjestionDatas";
-import { CongestionData } from "@/types/CongestionType";
+import { congestionList } from "@/mocks/handlers/dashboard/CongestionRead.handlers";
+import { GetCongestionTimeValue } from "@/types/api/ApiResponseType";
 
 import {
   AreaChart,
@@ -14,12 +14,12 @@ import {
 } from "recharts";
 
 type Props = {
-  dayData: CongestionData[];
+  dayData: GetCongestionTimeValue[];
 };
 
 export default function CongestionChart({ dayData }: Props) {
   // y축 최댓값: 모든 요일 데이터 중 가장 큰 value
-  const allValues = Object.values(CongestionDatas)
+  const allValues = Object.values(congestionList)
     .flat()
     .map(d => d.value);
 

--- a/src/pages/dashboardPage/views/DashBoardCongestion.tsx
+++ b/src/pages/dashboardPage/views/DashBoardCongestion.tsx
@@ -2,12 +2,14 @@ import { useState } from "react";
 import { Days } from "@/constants/dashboard/Days";
 import { formatDay } from "@/utils/FormatDay";
 import DashBoardTitle from "@/pages/dashboardPage/views/DashBoardTitle";
-import { CongestionDatas } from "@/mocks/handlers/dashboard/ConjestionDatas";
 import CongestionChart from "@/pages/dashboardPage/views/CongestionChart";
+import { useCongestionApi } from "@/hooks/api/useDashboardApi";
 
 export default function DashBoardCongestion() {
   const today = new Date().getDay(); // 0(일) - 6(토)
   const [selectedDay, setSelectedDay] = useState(Days[today - 1]); // default: 오늘 요일이 기본으로 보임.
+  const { data } = useCongestionApi();
+  const dayData = data?.[selectedDay] ?? [];
 
   return (
     <div className="flex flex-col">
@@ -30,7 +32,7 @@ export default function DashBoardCongestion() {
 
         {/* 혼잡도 그래프 */}
         <div className="absolute bottom-6 w-[612px] h-[394px] bg-gray01 rounded-[40px] flex justify-center">
-          <CongestionChart dayData={CongestionDatas[selectedDay]} />
+          <CongestionChart dayData={dayData} />
         </div>
       </div>
     </div>

--- a/src/pages/itemCreatePage/ItemCreatePage.tsx
+++ b/src/pages/itemCreatePage/ItemCreatePage.tsx
@@ -97,7 +97,7 @@ export default function ItemCreatePage() {
   useEffect(() => {
     return () => {
       const currentPath = location.pathname;
-      if (!currentPath.includes("/patch/")) {
+      if (!currentPath.includes("/edit")) {
         resetSelectedItem();
       }
     };

--- a/src/types/CongestionType.ts
+++ b/src/types/CongestionType.ts
@@ -1,10 +1,1 @@
 export type DayOfWeek = "mon" | "tue" | "wed" | "thu" | "fri" | "sat" | "sun";
-
-// export type CongestionData = {
-//   time: number;
-//   value: number;
-// };
-
-// export type CongestionType = {
-//   [_key in DayOfWeek]: CongestionData[];
-// };

--- a/src/types/CongestionType.ts
+++ b/src/types/CongestionType.ts
@@ -1,10 +1,10 @@
 export type DayOfWeek = "mon" | "tue" | "wed" | "thu" | "fri" | "sat" | "sun";
 
-export type CongestionData = {
-  time: number;
-  value: number;
-};
+// export type CongestionData = {
+//   time: number;
+//   value: number;
+// };
 
-export type CongestionType = {
-  [_key in DayOfWeek]: CongestionData[];
-};
+// export type CongestionType = {
+//   [_key in DayOfWeek]: CongestionData[];
+// };

--- a/src/types/api/ApiResponseType.ts
+++ b/src/types/api/ApiResponseType.ts
@@ -1,3 +1,4 @@
+import { DayOfWeek } from "@/types/CongestionType";
 import { ItemType } from "../ItemType";
 
 export type ApiResponse<T> = Promise<GlobalResponse<T>>;
@@ -83,3 +84,12 @@ export type GetBestItemsResponse = {
   price: number;
   stock: number;
 }[];
+
+export type GetCongestionTimeValue = {
+  time: number;
+  value: number;
+};
+
+export type GetCongestionResponse = Partial<
+  Record<DayOfWeek, GetCongestionTimeValue[]>
+>;


### PR DESCRIPTION
## 🌱 관련 이슈

- [LCR-120]

---

## 📌 작업 내용 및 특이사항

- 대시보드 혼잡도 분석 조회 기능 구현하였습니다.
- MSW로 mocking 하여 API 콘솔에서 테스트 가능합니다.
- 타입 정의: GetCongestionResponse, GetCongestionTimeValue 추가
- API 구현: getCongestion() 작성
- 훅 추가: useCongestionApi로 조회
- MSW 핸들러: CongestionReadHandlers로 목업 응답 제공
- 컴포넌트 연동: DashBoardCongestion.tsx에서 dayData를 CongestionChart에 전달

- 추후 추가적으로 데이터 없을 때 UI도 구상해보겠습니다.

---

## 📚 참고사항
<img width="1626" alt="image" src="https://github.com/user-attachments/assets/072ff6a5-3b6b-4047-8cd0-3e3fd8c0e9ff" />



[LCR-120]: https://lgcns-retail.atlassian.net/browse/LCR-120?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ