### PR TITLE
feat: 상품 수정 페이지 기능 구현

### DIFF
--- a/src/apis/ItemCreateApi.ts
+++ b/src/apis/ItemCreateApi.ts
@@ -1,12 +1,30 @@
 import { api } from "@/apis/config/Axios";
 import { usePopUpReadStore } from "@/stores/usePopUpReadStore";
-import { ItemCreateRequest } from "@/types/api/ApiRequestType";
-import { ApiResponse, NoResponse } from "@/types/api/ApiResponseType";
+import {
+  ItemCreateRequest,
+  PatchItemRequest,
+} from "@/types/api/ApiRequestType";
+import {
+  ApiResponse,
+  NoResponse,
+  PatchItemResponse,
+} from "@/types/api/ApiResponseType";
 
 export const postItemCreate = async (
   data: ItemCreateRequest,
 ): ApiResponse<NoResponse> => {
   const popupId = usePopUpReadStore.getState().popupId;
   const response = await api.post(`/popups/${popupId}/items`, data);
+  return response.data;
+};
+
+export const patchItem = async ({
+  itemId,
+  minStock,
+}: PatchItemRequest): ApiResponse<PatchItemResponse> => {
+  const popupId = usePopUpReadStore.getState().popupId;
+  const response = await api.patch(`/popups/${popupId}/items/${itemId}`, {
+    minStock,
+  });
   return response.data;
 };

--- a/src/apis/ItemListApi.ts
+++ b/src/apis/ItemListApi.ts
@@ -1,4 +1,8 @@
-import { ApiResponse, GetItemListResponse } from "@/types/api/ApiResponseType";
+import {
+  ApiResponse,
+  GetItemListResponse,
+  NoResponse,
+} from "@/types/api/ApiResponseType";
 import { api } from "./config/Axios";
 import { usePopUpReadStore } from "@/stores/usePopUpReadStore";
 
@@ -8,14 +12,8 @@ export const getItemList = async (): ApiResponse<GetItemListResponse> => {
   return response.data;
 };
 
-export const deleteItem = async (itemId: string) => {
+export const deleteItem = async (itemId: string): ApiResponse<NoResponse> => {
   const popupId = usePopUpReadStore.getState().popupId;
   const response = await api.delete(`/popups/${popupId}/items/${itemId}`);
-  return response.data;
-};
-
-export const patchItem = async (itemId: string) => {
-  const popupId = usePopUpReadStore.getState().popupId;
-  const response = await api.patch(`/popup/${popupId}/items/${itemId}`);
   return response.data;
 };

--- a/src/apis/ItemListApi.ts
+++ b/src/apis/ItemListApi.ts
@@ -13,3 +13,9 @@ export const deleteItem = async (itemId: string) => {
   const response = await api.delete(`/popups/${popupId}/items/${itemId}`);
   return response.data;
 };
+
+export const patchItem = async (itemId: string) => {
+  const popupId = usePopUpReadStore.getState().popupId;
+  const response = await api.patch(`/popup/${popupId}/items/${itemId}`);
+  return response.data;
+};

--- a/src/components/common/CustomInput.tsx
+++ b/src/components/common/CustomInput.tsx
@@ -16,6 +16,7 @@ type Props = {
   placeholder: string;
   width?: number;
   height?: number;
+  isPatch?: boolean;
 };
 
 export default function CustomInput({
@@ -28,6 +29,7 @@ export default function CustomInput({
   placeholder,
   width = 500,
   height = 60,
+  isPatch = false,
 }: Props) {
   const numberHandler = (e: React.FormEvent<HTMLInputElement>) => {
     if (isOnlyNumber) {
@@ -48,15 +50,21 @@ export default function CustomInput({
       <p lang={titleType} className="text-[20px] font-semibold">
         {title}
       </p>
-      <input
-        className="border rounded-full pl-[24px] border-gray05 bg-gray02 placeholder:text-gray07 text-gray10 text-[19px] transition-all duration-200 focus:border-gray09 focus:outline-none"
-        style={{ width: `${width}px`, height: `${height}px` }}
-        type={inputType || "text"}
-        placeholder={placeholder}
-        onChange={onChange}
-        value={value}
-        onInput={isOnlyNumber ? numberHandler : undefined}
-      />
+      {isPatch ? (
+        <div className="border rounded-full pl-[24px] border-gray05 bg-gray02 placeholder:text-gray07 text-gray10 text-[19px] transition-all duration-200 focus:border-gray09 focus:outline-none">
+          {value}
+        </div>
+      ) : (
+        <input
+          className="border rounded-full pl-[24px] border-gray05 bg-gray02 placeholder:text-gray07 text-gray10 text-[19px] transition-all duration-200 focus:border-gray09 focus:outline-none"
+          style={{ width: `${width}px`, height: `${height}px` }}
+          type={inputType || "text"}
+          placeholder={placeholder}
+          onChange={onChange}
+          value={value}
+          onInput={isOnlyNumber ? numberHandler : undefined}
+        />
+      )}
     </div>
   );
 }

--- a/src/components/common/CustomInput.tsx
+++ b/src/components/common/CustomInput.tsx
@@ -16,7 +16,7 @@ type Props = {
   placeholder: string;
   width?: number;
   height?: number;
-  isPatch?: boolean;
+  isPatchMode?: boolean;
 };
 
 export default function CustomInput({
@@ -29,7 +29,7 @@ export default function CustomInput({
   placeholder,
   width = 500,
   height = 60,
-  isPatch = false,
+  isPatchMode = false,
 }: Props) {
   const numberHandler = (e: React.FormEvent<HTMLInputElement>) => {
     if (isOnlyNumber) {
@@ -50,9 +50,15 @@ export default function CustomInput({
       <p lang={titleType} className="text-[20px] font-semibold">
         {title}
       </p>
-      {isPatch ? (
-        <div className="border rounded-full pl-[24px] border-gray05 bg-gray02 placeholder:text-gray07 text-gray10 text-[19px] transition-all duration-200 focus:border-gray09 focus:outline-none">
-          {value}
+      {isPatchMode ? (
+        <div
+          className="relative"
+          style={{ width: `${width}px`, height: `${height}px` }}
+        >
+          <div className="border rounded-full pl-[24px] border-gray05 bg-gray02 placeholder:text-gray07 text-gray10 text-[19px] focus:border-gray09 focus:outline-none absolute w-full h-full flex items-center">
+            {value}
+          </div>
+          <div className="absolute inset-0 rounded-full bg-gray10/30 flex items-center justify-center z-10" />
         </div>
       ) : (
         <input

--- a/src/hooks/api/useItemCreateApi.ts
+++ b/src/hooks/api/useItemCreateApi.ts
@@ -1,5 +1,5 @@
 import { postCreatePresignedUrl, putImageToS3 } from "@/apis/image/ImageApi";
-import { postItemCreate } from "@/apis/ItemCreateApi";
+import { patchItem, postItemCreate } from "@/apis/ItemCreateApi";
 import { ErrorMessage } from "@/utils/ErrorMessage";
 import { useMutation } from "@tanstack/react-query";
 
@@ -25,9 +25,17 @@ export const useItemCreateApi = () => {
     },
   });
 
+  const patchItemMutation = useMutation({
+    mutationFn: patchItem,
+    onError: error => {
+      throw new Error(`아이템 패치 에러 : ${ErrorMessage(error)}`);
+    },
+  });
+
   return {
     getItemPresignedUrlMutation,
     uploadItemImgToS3Mutation,
     itemCreateMutation,
+    patchItemMutation,
   };
 };

--- a/src/hooks/api/useItemListApi.ts
+++ b/src/hooks/api/useItemListApi.ts
@@ -1,4 +1,4 @@
-import { deleteItem, getItemList, patchItem } from "@/apis/ItemListApi";
+import { deleteItem, getItemList } from "@/apis/ItemListApi";
 import { ErrorMessage } from "@/utils/ErrorMessage";
 import { useMutation, useQuery } from "@tanstack/react-query";
 
@@ -30,14 +30,5 @@ export const useItemDeleteApi = () => {
     },
   });
 
-  const patchItemMutation = useMutation({
-    mutationFn: async (itemId: string) => {
-      await patchItem(itemId);
-    },
-    onError: error => {
-      throw new Error(`아이템 수정 에러 : ${ErrorMessage(error)}`);
-    },
-  });
-
-  return { deleteItemMutation, patchItemMutation };
+  return { deleteItemMutation };
 };

--- a/src/hooks/api/useItemListApi.ts
+++ b/src/hooks/api/useItemListApi.ts
@@ -1,4 +1,4 @@
-import { deleteItem, getItemList } from "@/apis/ItemListApi";
+import { deleteItem, getItemList, patchItem } from "@/apis/ItemListApi";
 import { ErrorMessage } from "@/utils/ErrorMessage";
 import { useMutation, useQuery } from "@tanstack/react-query";
 
@@ -29,5 +29,15 @@ export const useItemDeleteApi = () => {
       throw new Error(`아이템 삭제 에러 : ${ErrorMessage(error)}`);
     },
   });
-  return { deleteItemMutation };
+
+  const patchItemMutation = useMutation({
+    mutationFn: async (itemId: string) => {
+      await patchItem(itemId);
+    },
+    onError: error => {
+      throw new Error(`아이템 수정 에러 : ${ErrorMessage(error)}`);
+    },
+  });
+
+  return { deleteItemMutation, patchItemMutation };
 };

--- a/src/hooks/useItemCreate.ts
+++ b/src/hooks/useItemCreate.ts
@@ -1,24 +1,17 @@
 import { ErrorMessage } from "@/utils/ErrorMessage";
-import { ItemCreateRequest } from "@/types/api/ApiRequestType";
+import {
+  ItemCreateRequest,
+  PatchItemRequest,
+} from "@/types/api/ApiRequestType";
 import { useItemCreateApi } from "@/hooks/api/useItemCreateApi";
 import { ImageType } from "@/types/ImageType";
 
-// 이 파일이 제일 중요. 이게 핵심 기능
-
-// 아래 로직 검증. 다 있으면 api 호출
-// return (
-//   itemName &&
-//   itemPrice &&
-//   itemStock &&
-//   itemMinStock &&
-//   itemLocation &&
-//   imageFile
-// );
 export const useItemCreate = () => {
   const {
     getItemPresignedUrlMutation,
     uploadItemImgToS3Mutation,
     itemCreateMutation,
+    patchItemMutation,
   } = useItemCreateApi();
 
   const uploadImage = async (imageFile: File): Promise<string> => {
@@ -65,5 +58,19 @@ export const useItemCreate = () => {
       throw new Error(`상품 등록 오류 ${ErrorMessage(error)}`);
     }
   };
-  return { createItem };
+
+  const patchItem = async ({ itemId, minStock }: PatchItemRequest) => {
+    try {
+      const response = await patchItemMutation.mutateAsync({
+        itemId,
+        minStock,
+      });
+
+      return response.data;
+    } catch (error) {
+      throw new Error(`상품 패치 오류 ${ErrorMessage(error)}`);
+    }
+  };
+
+  return { createItem, patchItem };
 };

--- a/src/mocks/browser.ts
+++ b/src/mocks/browser.ts
@@ -10,7 +10,6 @@ import {
 import { ItemCreateHandlers } from "./handlers/itemCreate/ItemCreate.handlers";
 import { StockNotificationListHandlers } from "@/mocks/handlers/noticeModal/StockNotificationList.handlers";
 import { ItemListHandlers } from "./handlers/itemList/ItemList.handlers";
-import { ItemCreateHandlers } from "./handlers/itemCreate/ItemCreate.handlers";
 
 export const handlers = [
   ...AuthHandlers,

--- a/src/mocks/browser.ts
+++ b/src/mocks/browser.ts
@@ -10,6 +10,7 @@ import {
 import { ItemCreateHandlers } from "./handlers/itemCreate/ItemCreate.handlers";
 import { StockNotificationListHandlers } from "@/mocks/handlers/noticeModal/StockNotificationList.handlers";
 import { ItemListHandlers } from "./handlers/itemList/ItemList.handlers";
+import { ItemCreateHandlers } from "./handlers/itemCreate/ItemCreate.handlers";
 
 export const handlers = [
   ...AuthHandlers,

--- a/src/mocks/handlers/itemCreate/ItemCreate.handlers.ts
+++ b/src/mocks/handlers/itemCreate/ItemCreate.handlers.ts
@@ -1,8 +1,12 @@
-import { ItemCreateRequest } from "@/types/api/ApiRequestType";
+import {
+  ItemCreateRequest,
+  PatchItemRequest,
+} from "@/types/api/ApiRequestType";
+import { PatchItemResponse } from "@/types/api/ApiResponseType";
 import { http, HttpResponse } from "msw";
 
 export const ItemCreateHandlers = [
-  http.post("/items", async ({ request }) => {
+  http.post("/popups/:popupId/items", async ({ request }) => {
     const requestBody = (await request.json()) as ItemCreateRequest;
     const { popupId, name, imageUrl, price, stock, minStock, location } =
       requestBody;
@@ -56,5 +60,40 @@ export const ItemCreateHandlers = [
 
   http.put(import.meta.env.VITE_TEST_PRESIGNED_URL as string, async () => {
     return new HttpResponse(null, { status: 200 });
+  }),
+
+  http.patch("/popups/:popupId/items/:itemId", async ({ request }) => {
+    const requestBody = (await request.json()) as PatchItemRequest;
+
+    if (!requestBody.minStock) {
+      return HttpResponse.json(
+        {
+          success: false,
+          status: 400,
+          data: "request Type 확인하세요",
+          timestamp: new Date().toISOString(),
+        },
+        { status: 400 },
+      );
+    }
+
+    return HttpResponse.json(
+      {
+        success: true,
+        status: 200,
+        data: {
+          itemId: "2",
+          popupId: "1",
+          name: "지수 포토카드",
+          imageUrl: "https://bucket/1",
+          price: 50000,
+          stock: 500,
+          minStock: 30,
+          location: "a1",
+        } as PatchItemResponse,
+        timestamp: "2024-06-16T16:44:52.7230313",
+      },
+      { status: 200 },
+    );
   }),
 ];

--- a/src/mocks/handlers/itemList/ItemList.handlers.ts
+++ b/src/mocks/handlers/itemList/ItemList.handlers.ts
@@ -6,7 +6,7 @@ import { http, HttpResponse } from "msw";
 const itemsDatabase: ItemListType = {
   A: [
     {
-      location: 1,
+      location: "1",
       itemId: "item1",
       name: "다용도 청소포",
       imageUrl: TestImage,
@@ -15,7 +15,7 @@ const itemsDatabase: ItemListType = {
       minStock: 20,
     },
     {
-      location: 2,
+      location: "2",
       itemId: "life002",
       name: "친환경 세제",
       imageUrl: TestImage,
@@ -24,7 +24,7 @@ const itemsDatabase: ItemListType = {
       minStock: 15,
     },
     {
-      location: 3,
+      location: "3",
       itemId: "life003",
       name: "대나무 빨대 세트",
       imageUrl: TestImage,
@@ -33,7 +33,7 @@ const itemsDatabase: ItemListType = {
       minStock: 10,
     },
     {
-      location: 4,
+      location: "4",
       itemId: "life004",
       name: "다용도 수납함",
       imageUrl: TestImage,
@@ -44,7 +44,7 @@ const itemsDatabase: ItemListType = {
   ],
   B: [
     {
-      location: 1,
+      location: "1",
       itemId: "tech001",
       name: "무선 충전기",
       imageUrl: TestImage,
@@ -53,7 +53,7 @@ const itemsDatabase: ItemListType = {
       minStock: 5,
     },
     {
-      location: 2,
+      location: "2",
       itemId: "tech002",
       name: "블루투스 스피커",
       imageUrl: TestImage,
@@ -62,7 +62,7 @@ const itemsDatabase: ItemListType = {
       minStock: 5,
     },
     {
-      location: 3,
+      location: "3",
       itemId: "tech003",
       name: "스마트 플러그",
       imageUrl: TestImage,
@@ -71,7 +71,7 @@ const itemsDatabase: ItemListType = {
       minStock: 10,
     },
     {
-      location: 4,
+      location: "4",
       itemId: "tech004",
       name: "LED 스탠드",
       imageUrl: TestImage,
@@ -82,7 +82,7 @@ const itemsDatabase: ItemListType = {
   ],
   C: [
     {
-      location: 1,
+      location: "1",
       itemId: "food001",
       name: "유기농 그래놀라",
       imageUrl: TestImage,
@@ -91,7 +91,7 @@ const itemsDatabase: ItemListType = {
       minStock: 15,
     },
     {
-      location: 2,
+      location: "2",
       itemId: "food002",
       name: "과일 주스 세트",
       imageUrl: TestImage,
@@ -100,7 +100,7 @@ const itemsDatabase: ItemListType = {
       minStock: 10,
     },
     {
-      location: 3,
+      location: "3",
       itemId: "food003",
       name: "건조 과일 믹스",
       imageUrl: TestImage,
@@ -109,7 +109,7 @@ const itemsDatabase: ItemListType = {
       minStock: 20,
     },
     {
-      location: 4,
+      location: "4",
       itemId: "food004",
       name: "견과류 선물세트",
       imageUrl: TestImage,
@@ -120,7 +120,7 @@ const itemsDatabase: ItemListType = {
   ],
   D: [
     {
-      location: 1,
+      location: "1",
       itemId: "cloth001",
       name: "면 티셔츠",
       imageUrl: TestImage,
@@ -129,7 +129,7 @@ const itemsDatabase: ItemListType = {
       minStock: 25,
     },
     {
-      location: 2,
+      location: "2",
       itemId: "cloth002",
       name: "데님 자켓",
       imageUrl: TestImage,
@@ -138,7 +138,7 @@ const itemsDatabase: ItemListType = {
       minStock: 5,
     },
     {
-      location: 3,
+      location: "3",
       itemId: "cloth003",
       name: "겨울 양말 세트",
       imageUrl: TestImage,
@@ -147,7 +147,7 @@ const itemsDatabase: ItemListType = {
       minStock: 20,
     },
     {
-      location: 4,
+      location: "4",
       itemId: "cloth004",
       name: "캐시미어 목도리",
       imageUrl: TestImage,

--- a/src/mocks/handlers/itemList/ItemList.handlers.ts
+++ b/src/mocks/handlers/itemList/ItemList.handlers.ts
@@ -12,6 +12,7 @@ const itemsDatabase: ItemListType = {
       imageUrl: TestImage,
       price: 5000,
       stock: 120,
+      minStock: 20,
     },
     {
       location: 2,
@@ -20,6 +21,7 @@ const itemsDatabase: ItemListType = {
       imageUrl: TestImage,
       price: 8900,
       stock: 85,
+      minStock: 15,
     },
     {
       location: 3,
@@ -28,6 +30,7 @@ const itemsDatabase: ItemListType = {
       imageUrl: TestImage,
       price: 12000,
       stock: 64,
+      minStock: 10,
     },
     {
       location: 4,
@@ -36,6 +39,7 @@ const itemsDatabase: ItemListType = {
       imageUrl: TestImage,
       price: 15000,
       stock: 42,
+      minStock: 8,
     },
   ],
   B: [
@@ -46,6 +50,7 @@ const itemsDatabase: ItemListType = {
       imageUrl: TestImage,
       price: 29000,
       stock: 37,
+      minStock: 5,
     },
     {
       location: 2,
@@ -54,6 +59,7 @@ const itemsDatabase: ItemListType = {
       imageUrl: TestImage,
       price: 45000,
       stock: 25,
+      minStock: 5,
     },
     {
       location: 3,
@@ -62,6 +68,7 @@ const itemsDatabase: ItemListType = {
       imageUrl: TestImage,
       price: 18500,
       stock: 58,
+      minStock: 10,
     },
     {
       location: 4,
@@ -70,6 +77,7 @@ const itemsDatabase: ItemListType = {
       imageUrl: TestImage,
       price: 34000,
       stock: 19,
+      minStock: 3,
     },
   ],
   C: [
@@ -80,6 +88,7 @@ const itemsDatabase: ItemListType = {
       imageUrl: TestImage,
       price: 12500,
       stock: 75,
+      minStock: 15,
     },
     {
       location: 2,
@@ -88,6 +97,7 @@ const itemsDatabase: ItemListType = {
       imageUrl: TestImage,
       price: 18000,
       stock: 42,
+      minStock: 10,
     },
     {
       location: 3,
@@ -96,6 +106,7 @@ const itemsDatabase: ItemListType = {
       imageUrl: TestImage,
       price: 9800,
       stock: 89,
+      minStock: 20,
     },
     {
       location: 4,
@@ -104,6 +115,7 @@ const itemsDatabase: ItemListType = {
       imageUrl: TestImage,
       price: 25000,
       stock: 31,
+      minStock: 5,
     },
   ],
   D: [
@@ -114,6 +126,7 @@ const itemsDatabase: ItemListType = {
       imageUrl: TestImage,
       price: 15000,
       stock: 120,
+      minStock: 25,
     },
     {
       location: 2,
@@ -122,6 +135,7 @@ const itemsDatabase: ItemListType = {
       imageUrl: TestImage,
       price: 59000,
       stock: 28,
+      minStock: 5,
     },
     {
       location: 3,
@@ -130,6 +144,7 @@ const itemsDatabase: ItemListType = {
       imageUrl: TestImage,
       price: 12000,
       stock: 95,
+      minStock: 20,
     },
     {
       location: 4,
@@ -138,6 +153,7 @@ const itemsDatabase: ItemListType = {
       imageUrl: TestImage,
       price: 38000,
       stock: 22,
+      minStock: 5,
     },
   ],
 };

--- a/src/pages/itemCreatePage/ItemCreatePage.tsx
+++ b/src/pages/itemCreatePage/ItemCreatePage.tsx
@@ -1,15 +1,16 @@
 import CustomButton from "@/components/common/CustomButton";
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import TestImage from "@/assets/webps/onBoarding/test.png";
 import Modal from "@/components/common/Modal";
 import bin from "@/assets/webps/common/bin.webp";
 import check from "@/assets/webps/common/check.webp";
-import { useNavigate } from "react-router-dom";
+import { useLocation, useNavigate } from "react-router-dom";
 import { useItemCreate } from "@/hooks/useItemCreate";
 import ItemCreateInputs from "@/pages/itemCreatePage/views/ItemCreateInputs";
+import { usePopUpReadStore } from "@/stores/usePopUpReadStore";
 
-export default function ItemAddPage() {
-  const [itemPopUpId] = useState<number>(1); // 추후 zustand로 전역 상태 관리
+export default function ItemCreatePage() {
+  const popupId = usePopUpReadStore.getState().popupId;
   const [itemName, setItemName] = useState<string>("");
   const [itemPrice, setItemPrice] = useState<number>(0);
   const [itemStock, setItemStock] = useState<number>(0);
@@ -18,9 +19,17 @@ export default function ItemAddPage() {
   const [imageFile, setImageFile] = useState<File | null>(null);
   const [isAlertModalOpen, setIsAlertModalOpen] = useState<boolean>(false);
   const [isSaveModalOpen, setIsSaveModalOpen] = useState<boolean>(false);
+  const [isPatch, setIsPatch] = useState<boolean>(false);
   const navigate = useNavigate();
 
   const { createItem } = useItemCreate();
+
+  const location = useLocation();
+  const item = location.state?.item;
+
+  useEffect(() => {
+    setIsPatch(isPatch);
+  }, [item]);
 
   const handleCancel = () => {
     setIsAlertModalOpen(true);
@@ -29,7 +38,7 @@ export default function ItemAddPage() {
   const handleSave = () => {
     setIsSaveModalOpen(true);
     return (
-      itemPopUpId &&
+      popupId &&
       itemName &&
       itemPrice &&
       itemStock &&
@@ -40,13 +49,11 @@ export default function ItemAddPage() {
   };
 
   const handleSaveConfirmBtn = async () => {
-    // createItem 호출
-    // createItem 안에다 위 state들 넘겨주면 생성됨
     if (!imageFile) return alert("이미지를 선택해주세요.");
     await createItem({
       imageFile,
       data: {
-        popupId: itemPopUpId,
+        popupId: popupId,
         name: itemName,
         price: itemPrice,
         stock: itemStock,
@@ -122,6 +129,7 @@ export default function ItemAddPage() {
           handleStock={handleStock}
           handleMinStock={handleMinStock}
           handleLocation={handleLocation}
+          isPatch={isPatch}
         />
       </div>
       <Modal

--- a/src/pages/itemCreatePage/views/ItemCreateInputs.tsx
+++ b/src/pages/itemCreatePage/views/ItemCreateInputs.tsx
@@ -12,6 +12,7 @@ type Props = {
   handleStock: (_e: React.ChangeEvent<HTMLInputElement>) => void;
   handleMinStock: (_e: React.ChangeEvent<HTMLInputElement>) => void;
   handleLocation: (_e: React.ChangeEvent<HTMLInputElement>) => void;
+  isPatch: boolean;
 };
 
 export default function ItemCreateInputs({
@@ -25,6 +26,7 @@ export default function ItemCreateInputs({
   handleStock,
   handleMinStock,
   handleLocation,
+  isPatch,
 }: Props) {
   return (
     <div className="flex flex-col gap-[30px]">
@@ -33,6 +35,7 @@ export default function ItemCreateInputs({
         title="상품명"
         placeholder="상품명을 입력해주세요"
         onChange={handleName}
+        isPatch={isPatch}
       />
       <CustomInput
         value={price}
@@ -40,6 +43,7 @@ export default function ItemCreateInputs({
         title="가격"
         placeholder="가격을 입력해주세요"
         onChange={handlePrice}
+        isPatch={isPatch}
       />
       <CustomInput
         value={stock}
@@ -47,6 +51,7 @@ export default function ItemCreateInputs({
         title="수량"
         placeholder="상품 수량을 입력해주세요"
         onChange={handleStock}
+        isPatch={isPatch}
       />
       <CustomInput
         value={minStock}
@@ -59,6 +64,7 @@ export default function ItemCreateInputs({
         title="로케이션"
         placeholder="상품 로케이션을 입력해주세요"
         onChange={handleLocation}
+        isPatch={isPatch}
       />
     </div>
   );

--- a/src/pages/itemCreatePage/views/ItemCreateInputs.tsx
+++ b/src/pages/itemCreatePage/views/ItemCreateInputs.tsx
@@ -1,5 +1,7 @@
 import CustomInput from "@/components/common/CustomInput";
+import { useSelectedItemStore } from "@/stores/useSelectedItemStore";
 import React from "react";
+import TestImage from "@/assets/webps/onBoarding/test.png";
 
 type Props = {
   name: string;
@@ -12,7 +14,9 @@ type Props = {
   handleStock: (_e: React.ChangeEvent<HTMLInputElement>) => void;
   handleMinStock: (_e: React.ChangeEvent<HTMLInputElement>) => void;
   handleLocation: (_e: React.ChangeEvent<HTMLInputElement>) => void;
-  isPatch: boolean;
+  imageFile: File | null;
+  handleImageFile: (_file: File) => void;
+  isPatchMode: boolean;
 };
 
 export default function ItemCreateInputs({
@@ -26,46 +30,79 @@ export default function ItemCreateInputs({
   handleStock,
   handleMinStock,
   handleLocation,
-  isPatch,
+  imageFile,
+  handleImageFile,
+  isPatchMode,
 }: Props) {
+  const { selectedItem, updateField } = useSelectedItemStore();
+
+  const handlePatchMinStock = (e: React.ChangeEvent<HTMLInputElement>) => {
+    updateField("minStock", Number(e.target.value));
+  };
+
   return (
-    <div className="flex flex-col gap-[30px]">
-      <CustomInput
-        value={name}
-        title="상품명"
-        placeholder="상품명을 입력해주세요"
-        onChange={handleName}
-        isPatch={isPatch}
-      />
-      <CustomInput
-        value={price}
-        isOnlyNumber={true}
-        title="가격"
-        placeholder="가격을 입력해주세요"
-        onChange={handlePrice}
-        isPatch={isPatch}
-      />
-      <CustomInput
-        value={stock}
-        isOnlyNumber={true}
-        title="수량"
-        placeholder="상품 수량을 입력해주세요"
-        onChange={handleStock}
-        isPatch={isPatch}
-      />
-      <CustomInput
-        value={minStock}
-        title="발주 기준 수량"
-        placeholder="상품 발주 기준 수량을 입력해주세요"
-        onChange={handleMinStock}
-      />
-      <CustomInput
-        value={location}
-        title="로케이션"
-        placeholder="상품 로케이션을 입력해주세요"
-        onChange={handleLocation}
-        isPatch={isPatch}
-      />
+    <div className="absolute left-[50%] mt-40 transform -translate-x-1/2 flex justify-center items-center gap-[53px]">
+      <div className="relative w-[400px] h-[400px]">
+        {/* 이미지 */}
+        <img
+          src={imageFile ? URL.createObjectURL(imageFile) : TestImage}
+          alt="상품 이미지"
+          width={400}
+          className="w-full h-full object-cover rounded-[20px]"
+        />
+        {!isPatchMode && (
+          <input
+            type="file"
+            accept="image/*"
+            onChange={e => {
+              const file = e.target.files?.[0];
+              if (file) handleImageFile(file);
+            }}
+            className="absolute inset-0 w-full h-full opacity-0 cursor-pointer z-10"
+          />
+        )}
+        {isPatchMode && (
+          <div className="absolute inset-0 rounded-[20px] bg-gray10/30 flex items-center justify-center" />
+        )}
+      </div>
+      <div className="flex flex-col gap-[30px]">
+        <CustomInput
+          value={isPatchMode && selectedItem ? selectedItem.name : name}
+          title="상품명"
+          placeholder="상품명을 입력해주세요"
+          onChange={handleName}
+          isPatchMode={isPatchMode}
+        />
+        <CustomInput
+          value={isPatchMode && selectedItem ? selectedItem.price : price}
+          isOnlyNumber={true}
+          title="가격"
+          placeholder="가격을 입력해주세요"
+          onChange={handlePrice}
+          isPatchMode={isPatchMode}
+        />
+        <CustomInput
+          value={isPatchMode && selectedItem ? selectedItem.stock : stock}
+          isOnlyNumber={true}
+          title="수량"
+          placeholder="상품 수량을 입력해주세요"
+          onChange={handleStock}
+          isPatchMode={isPatchMode}
+        />
+        <CustomInput
+          value={isPatchMode && selectedItem ? selectedItem.minStock : minStock}
+          title="발주 기준 수량"
+          placeholder="상품 발주 기준 수량을 입력해주세요"
+          onChange={isPatchMode ? handlePatchMinStock : handleMinStock}
+        />
+        <CustomInput
+          value={isPatchMode && selectedItem ? selectedItem.location : location}
+          title="로케이션"
+          placeholder="상품 로케이션을 입력해주세요"
+          onChange={handleLocation}
+          isPatchMode={isPatchMode}
+        />
+      </div>
     </div>
   );
 }

--- a/src/pages/itemListPage/views/ItemDisplay.tsx
+++ b/src/pages/itemListPage/views/ItemDisplay.tsx
@@ -4,6 +4,7 @@ import bin from "@/assets/webps/common/bin.webp";
 import check from "@/assets/webps/common/check.webp";
 import { useState } from "react";
 import { useItemDeleteApi } from "@/hooks/api/useItemListApi";
+import { useNavigate } from "react-router-dom";
 
 type Props = {
   displayName: string;
@@ -15,6 +16,7 @@ export default function ItemDisplay({ displayName, items }: Props) {
   const [selectedItem, setSelectedItem] = useState<ItemType | null>(null);
   const [isDeleteConfirmOpen, setIsDeleteConfirmOpen] = useState(false);
   const { deleteItemMutation } = useItemDeleteApi();
+  const navigate = useNavigate();
 
   const handleOpenDeleteModal = (item: ItemType) => {
     setSelectedItem(item);
@@ -29,6 +31,13 @@ export default function ItemDisplay({ displayName, items }: Props) {
     await deleteItemMutation.mutateAsync(selectedItem.itemId);
     setIsModalOpen(false);
     setIsDeleteConfirmOpen(true);
+  };
+
+  const handlePatchBtn = (item: ItemType) => {
+    setSelectedItem(item);
+    navigate(`/items/patch/${item.itemId}`, {
+      state: item,
+    });
   };
 
   return (
@@ -59,12 +68,19 @@ export default function ItemDisplay({ displayName, items }: Props) {
             <p className="text-[16px] text-gray08 mb-1">
               {item.price.toLocaleString()}원
             </p>
+            <p className="text-[16px] text-gray08 mb-1">
+              최소 발주 수량 : {item.minStock}
+            </p>
             <p className="text-[16px] text-gray08 mb-2">
               남은재고 : {item.stock}
             </p>
+
             <div className="flex gap-2">
               <div className="flex justify-center gap-4 mt-2">
-                <button className="text-[18px] px-4 py-1 cursor-pointer bg-gray10 text-gray01 rounded-full hover:opacity-90">
+                <button
+                  className="text-[18px] px-4 py-1 cursor-pointer bg-gray10 text-gray01 rounded-full hover:opacity-90"
+                  onClick={() => handlePatchBtn(item)}
+                >
                   수정
                 </button>
                 <button

--- a/src/pages/itemListPage/views/ItemDisplay.tsx
+++ b/src/pages/itemListPage/views/ItemDisplay.tsx
@@ -5,6 +5,7 @@ import check from "@/assets/webps/common/check.webp";
 import { useState } from "react";
 import { useItemDeleteApi } from "@/hooks/api/useItemListApi";
 import { useNavigate } from "react-router-dom";
+import { useSelectedItemStore } from "@/stores/useSelectedItemStore";
 
 type Props = {
   displayName: string;
@@ -13,9 +14,10 @@ type Props = {
 
 export default function ItemDisplay({ displayName, items }: Props) {
   const [isModalOpen, setIsModalOpen] = useState(false);
-  const [selectedItem, setSelectedItem] = useState<ItemType | null>(null);
   const [isDeleteConfirmOpen, setIsDeleteConfirmOpen] = useState(false);
   const { deleteItemMutation } = useItemDeleteApi();
+  const { selectedItem, setSelectedItem, resetSelectedItem } =
+    useSelectedItemStore();
   const navigate = useNavigate();
 
   const handleOpenDeleteModal = (item: ItemType) => {
@@ -27,17 +29,15 @@ export default function ItemDisplay({ displayName, items }: Props) {
     if (!selectedItem) {
       return null;
     }
-
     await deleteItemMutation.mutateAsync(selectedItem.itemId);
     setIsModalOpen(false);
     setIsDeleteConfirmOpen(true);
+    resetSelectedItem();
   };
 
   const handlePatchBtn = (item: ItemType) => {
     setSelectedItem(item);
-    navigate(`/items/patch/${item.itemId}`, {
-      state: item,
-    });
+    navigate(`/items/patch/${item.itemId}`);
   };
 
   return (
@@ -48,8 +48,6 @@ export default function ItemDisplay({ displayName, items }: Props) {
         </div>
         <div className="flex-1 h-px bg-gray05" />
       </div>
-
-      {/* 상품 카드 리스트 */}
       <div
         className="grid grid-cols-4 gap-6 gap-y-14 "
         style={{ paddingLeft: "272px", paddingRight: "180px" }}

--- a/src/router/Router.tsx
+++ b/src/router/Router.tsx
@@ -1,7 +1,7 @@
 import GlobalLayout from "@/components/layouts/GlobalLayout";
 import ProtectLayout from "@/components/layouts/ProtectLayout";
 import DashBoardPage from "@/pages/dashboardPage/DashBoardPage";
-import ItemAddPage from "@/pages/itemCreatePage/ItemCreatePage";
+import ItemCreatePage from "@/pages/itemCreatePage/ItemCreatePage";
 import ItemListPage from "@/pages/itemListPage/ItemListPage";
 import OnBoradingPage from "@/pages/onBoardingPage/OnBoardingPage";
 import PopUpCreatePage from "@/pages/popUpCreatePage/PopUpCreatePage";
@@ -24,7 +24,7 @@ export const Router = createBrowserRouter([
           },
           {
             path: "/items/create",
-            element: <ItemAddPage />,
+            element: <ItemCreatePage />,
           },
           {
             path: "/items",

--- a/src/router/Router.tsx
+++ b/src/router/Router.tsx
@@ -31,6 +31,10 @@ export const Router = createBrowserRouter([
             element: <ItemListPage />,
           },
           {
+            path: "/items/patch/:itemId",
+            element: <ItemCreatePage />,
+          },
+          {
             path: "/popup-create",
             element: <PopUpCreatePage />,
           },

--- a/src/stores/useSelectedItemStore.ts
+++ b/src/stores/useSelectedItemStore.ts
@@ -1,0 +1,36 @@
+import { ItemType } from "@/types/ItemType";
+import { create } from "zustand";
+import { persist, createJSONStorage } from "zustand/middleware";
+
+type ItemStoreState = {
+  selectedItem: ItemType | null;
+  setSelectedItem: (_item: ItemType) => void;
+  updateField: <K extends keyof ItemType>(
+    _field: K,
+    _value: ItemType[K],
+  ) => void;
+  resetSelectedItem: () => void;
+};
+
+export const useSelectedItemStore = create<ItemStoreState>()(
+  persist(
+    set => ({
+      selectedItem: null,
+      setSelectedItem: item => set({ selectedItem: item }),
+      updateField: (field, value) =>
+        set(state => ({
+          selectedItem: state.selectedItem
+            ? { ...state.selectedItem, [field]: value }
+            : null,
+        })),
+      resetSelectedItem: () => set({ selectedItem: null }),
+    }),
+    {
+      name: "selected-item-storage",
+      storage: createJSONStorage(() => localStorage),
+      partialize: state => ({
+        selectedItem: state.selectedItem,
+      }),
+    },
+  ),
+);

--- a/src/types/ItemType.ts
+++ b/src/types/ItemType.ts
@@ -5,6 +5,7 @@ export type ItemType = {
   stock: number;
   location: number;
   imageUrl: string;
+  minStock: number;
 };
 
 export type BestItemType = {

--- a/src/types/ItemType.ts
+++ b/src/types/ItemType.ts
@@ -3,7 +3,7 @@ export type ItemType = {
   name: string;
   price: number;
   stock: number;
-  location: number;
+  location: string;
   imageUrl: string;
   minStock: number;
 };

--- a/src/types/api/ApiRequestType.ts
+++ b/src/types/api/ApiRequestType.ts
@@ -48,3 +48,8 @@ export type PopUpWithChoicesRequest = {
   popupCreateRequest: PopUpCreateRequest;
   choiceCreateRequestList: ChoiceCreateRequest[];
 };
+
+export type PatchItemRequest = {
+  itemId: string;
+  minStock: number;
+};

--- a/src/types/api/ApiResponseType.ts
+++ b/src/types/api/ApiResponseType.ts
@@ -64,3 +64,14 @@ export type GetStockNotificationResponse = {
 };
 
 export type GetStockNotificationListResponse = GetStockNotificationResponse[];
+
+export type PatchItemResponse = {
+  itemId: string;
+  popupId: string;
+  name: string;
+  imageUrl: string;
+  price: number;
+  stock: number;
+  minStock: number;
+  location: string;
+};

--- a/src/utils/ValidateAllField.ts
+++ b/src/utils/ValidateAllField.ts
@@ -1,0 +1,67 @@
+/**
+ * 객체의 모든 필드가 null, undefined가 아닌지 검증하는 유틸함수입니다.
+ *
+ * @param data 검증할 객체
+ * @param allowZero 0 값을 허용할지 여부 (기본값: true)
+ * @param allowEmptyString 빈 문자열을 허용할지 여부 (기본값: false)
+ * @returns 모든 필드가 유효하면 true, 아니면 false
+ */
+export const ValidateAllField = (
+  data: object,
+  allowZero: boolean = true,
+  allowEmptyString: boolean = false,
+): boolean => {
+  return Object.values(data).every(value => {
+    // null 또는 undefined 검사
+    if (value === null || value === undefined) {
+      return false;
+    }
+
+    // 숫자 0 검사
+    if (value === 0) {
+      return allowZero;
+    }
+
+    // 빈 문자열 검사
+    if (value === "") {
+      return allowEmptyString;
+    }
+
+    return true;
+  });
+};
+
+/**
+ * 객체에서 유효하지 않은 필드를 찾아 반환하는 유틸함수입니다.
+ *
+ * @param data 검증할 객체
+ * @param allowZero 0 값을 허용할지 여부 (기본값: true)
+ * @param allowEmptyString 빈 문자열을 허용할지 여부 (기본값: false)
+ * @returns 유효하지 않은 필드명의 배열, 모두 유효하면 빈 배열
+ */
+export const FindInvalidFields = (
+  data: object,
+  allowZero: boolean = true,
+  allowEmptyString: boolean = false,
+): string[] => {
+  return Object.entries(data)
+    .filter(([, value]) => {
+      // null 또는 undefined 검사
+      if (value === null || value === undefined) {
+        return true;
+      }
+
+      // 숫자 0 검사
+      if (value === 0 && !allowZero) {
+        return true;
+      }
+
+      // 빈 문자열 검사
+      if (value === "" && !allowEmptyString) {
+        return true;
+      }
+
+      return false;
+    })
+    .map(([key]) => key);
+};


### PR DESCRIPTION
## 🌱 관련 이슈

- [LCR-115]

---

## 📌 작업 내용 및 특이사항

- 최소 발주 수량 수정 기능 구현했습니다.
- 상품 생성 페이지를 재사용했고, 상품 리스트 페이지에서 전역 변수를 사용하여 선택된 대상의 상태를 관리하도록 구현했습니다.
    - 상품 수정 페이지에서 새로고침하면 상태로 관리되기 때문에 데이터가 날아가서 localStorage에 선택된 대상을 저장하도록 persist를 사용했습니다.
    - 일부 코드 개선했습니다

---

## 📚 참고사항

<img width="882" alt="image" src="https://github.com/user-attachments/assets/8bf5528c-a210-4890-b235-9ff4f913882e" />
<img width="895" alt="image" src="https://github.com/user-attachments/assets/d97ced4d-0ee5-4606-b486-baa9d3d8ec50" />



[LCR-115]: https://lgcns-retail.atlassian.net/browse/LCR-115?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ