### PR TITLE
refactor: tanstack-query 캐시 전략 구성

### DIFF
--- a/src/hooks/api/useItemCreateApi.ts
+++ b/src/hooks/api/useItemCreateApi.ts
@@ -2,10 +2,11 @@ import { postCreatePresignedUrl, putImageToS3 } from "@/apis/image/ImageApi";
 import { patchItem, postItemCreate } from "@/apis/ItemCreateApi";
 import { postItemAddExcel } from "@/apis/ItemListApi";
 import { ErrorMessage } from "@/utils/ErrorMessage";
-import { useMutation } from "@tanstack/react-query";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useState } from "react";
 
 export const useItemCreateApi = () => {
+  const queryClient = useQueryClient();
   const [onProgress, setOnProgress] = useState<number>(0);
 
   const getItemPresignedUrlMutation = useMutation({
@@ -24,6 +25,9 @@ export const useItemCreateApi = () => {
 
   const itemCreateMutation = useMutation({
     mutationFn: postItemCreate,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["itemList"] });
+    },
     onError: error => {
       throw new Error(`상품 생성 에러 : ${ErrorMessage(error)}`);
     },
@@ -31,6 +35,9 @@ export const useItemCreateApi = () => {
 
   const patchItemMutation = useMutation({
     mutationFn: patchItem,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["itemList"] });
+    },
     onError: error => {
       throw new Error(`아이템 패치 에러 : ${ErrorMessage(error)}`);
     },
@@ -46,6 +53,7 @@ export const useItemCreateApi = () => {
       }),
     onSuccess: () => {
       setOnProgress(100);
+      queryClient.invalidateQueries({ queryKey: ["itemList"] });
     },
     onError: error => {
       setOnProgress(0);

--- a/src/hooks/api/useItemListApi.ts
+++ b/src/hooks/api/useItemListApi.ts
@@ -1,10 +1,10 @@
 import { deleteItem, getItemList } from "@/apis/ItemListApi";
 import { ErrorMessage } from "@/utils/ErrorMessage";
-import { useMutation, useQuery } from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 
 export const useItemListApi = () => {
   const { data, isLoading, isError, error, refetch } = useQuery({
-    queryKey: ["popups"],
+    queryKey: ["itemList"],
     queryFn: async () => {
       const response = await getItemList();
       return response.data;
@@ -21,9 +21,13 @@ export const useItemListApi = () => {
 };
 
 export const useItemDeleteApi = () => {
+  const queryClient = useQueryClient();
   const deleteItemMutation = useMutation({
     mutationFn: async (itemId: string) => {
       await deleteItem(itemId);
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["itemList"] });
     },
     onError: error => {
       throw new Error(`아이템 삭제 에러 : ${ErrorMessage(error)}`);

--- a/src/hooks/api/usePopUpCreateApi.ts
+++ b/src/hooks/api/usePopUpCreateApi.ts
@@ -1,9 +1,10 @@
 import { postCreatePresignedUrl, putImageToS3 } from "@/apis/image/ImageApi";
 import { postPopUpCreate } from "@/apis/PopUpCreateApi";
 import { ErrorMessage } from "@/utils/ErrorMessage";
-import { useMutation } from "@tanstack/react-query";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 
 export const usePopUpCreateApi = () => {
+  const queryClient = useQueryClient();
   const getPresignedUrlMutation = useMutation({
     mutationFn: postCreatePresignedUrl,
     onError: error => {
@@ -20,6 +21,9 @@ export const usePopUpCreateApi = () => {
 
   const postPopUpCreateMutation = useMutation({
     mutationFn: postPopUpCreate,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["popUpList"] });
+    },
     onError: error => {
       throw new Error(`팝업 등록 에러 : ${ErrorMessage(error)}`);
     },


### PR DESCRIPTION
## 🌱 관련 이슈

- [LCR-135]

---

## 📌 작업 내용 및 특이사항

- tanstack-query 캐시 전략 구성하였습니다.
- GET할 때 지정했던 queryKey 를 `POST`, `PATCH`, `DELETE` 메서드에서 사용해, onSuccess 일 때 캐시 무효화 처리를 진행하였습니다.
```
queryClient.invalidateQueries({ queryKey: ["itemList"] });
```
- `presigned url 발급 POST` 및 `S3에 업로드하는 PUT`, 캐싱되어야하는 `GET 메서드` 를 제외한 모든 API 에 캐시 무효화를 지정하였습니다.
---

## 📚 참고사항
<img width="242" alt="image" src="https://github.com/user-attachments/assets/3c2e219e-f44b-43a0-8747-a5ca6fd05af4" />

예시로, 처음 상품 목록 페이지 들어왔을 때 items에서 GET을 받고, 상품을 등록해서 presigned-url에 POST 및 items에 POST, 다시 상품 목록 페이지로 리다이렉션 되었을 때 캐시 무효화되어 items에서 GET을 받는 것을 확인할 수 있습니다.


[LCR-135]: https://lgcns-retail.atlassian.net/browse/LCR-135?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ