### PR TITLE
chore: Playwright 설정 추가

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -16,10 +16,10 @@ jobs:
         node-version: [20.x]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
           cache: "npm"
@@ -41,10 +41,10 @@ jobs:
     needs: build-and-test
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Use Node.js 20.x
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 20.x
           cache: "npm"
@@ -63,7 +63,7 @@ jobs:
           VITE_TEST_PRESIGNED_URL: ${{ secrets.VITE_TEST_PRESIGNED_URL }}
 
       - name: Upload Playwright Report
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: playwright-report
@@ -71,7 +71,7 @@ jobs:
           retention-days: 30
 
       - name: Upload screenshots
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: playwright-screenshots

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -5,6 +5,7 @@ on:
     branches: [main, develop]
   pull_request:
     branches: [main, develop]
+  workflow_dispatch:
 
 jobs:
   build-and-test:
@@ -34,3 +35,44 @@ jobs:
 
       - name: 단위 테스트
         run: npm run test
+
+  e2e-tests:
+    runs-on: ubuntu-latest
+    needs: build-and-test
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Use Node.js 20.x
+        uses: actions/setup-node@v3
+        with:
+          node-version: 20.x
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright Browsers
+        run: npx playwright install --with-deps
+
+      - name: E2E 테스트
+        run: npx playwright test
+        env:
+          VITE_API_URL: dev-api.ceo.popi.today
+          VITE_KAKAO_MAP_API_KEY: ${{ secrets.VITE_KAKAO_MAP_API_KEY }}
+          VITE_TEST_PRESIGNED_URL: ${{ secrets.VITE_TEST_PRESIGNED_URL }}
+
+      - name: Upload Playwright Report
+        uses: actions/upload-artifact@v3
+        if: always()
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 30
+
+      - name: Upload screenshots
+        uses: actions/upload-artifact@v3
+        if: failure()
+        with:
+          name: playwright-screenshots
+          path: test-results/

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -58,7 +58,8 @@ jobs:
       - name: E2E 테스트
         run: npx playwright test
         env:
-          VITE_API_URL: dev-api.ceo.popi.today
+          VITE_DNS_URL: ${{ secrets.VITE_DNS_URL }}
+          VITE_API_URL: ${{ secrets.VITE_API_URL }}
           VITE_KAKAO_MAP_API_KEY: ${{ secrets.VITE_KAKAO_MAP_API_KEY }}
           VITE_TEST_PRESIGNED_URL: ${{ secrets.VITE_TEST_PRESIGNED_URL }}
 

--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,7 @@ pnpm-debug.log*
 
 # https pem 파일
 localhost*
+
+test-results
+playwright-report
+tests/auth.json

--- a/chromatic.config.json
+++ b/chromatic.config.json
@@ -1,5 +1,0 @@
-{
-  "onlyChanged": true,
-  "projectId": "Project:68145e4fb508a397a4f41502",
-  "zip": true
-}

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
       "devDependencies": {
         "@chromatic-com/storybook": "^3.2.6",
         "@eslint/js": "^9.17.0",
+        "@playwright/test": "^1.52.0",
         "@storybook/addon-designs": "^8.2.1",
         "@storybook/addon-essentials": "^8.6.12",
         "@storybook/addon-onboarding": "^8.6.12",
@@ -42,6 +43,7 @@
         "@vitejs/plugin-react": "^4.3.4",
         "@vitest/browser": "^3.1.1",
         "@vitest/coverage-v8": "^3.1.1",
+        "dotenv": "^16.5.0",
         "eslint": "^8.57.1",
         "eslint-config-prettier": "^10.1.2",
         "eslint-plugin-import": "^2.31.0",
@@ -1541,6 +1543,22 @@
       },
       "funding": {
         "url": "https://opencollective.com/unts"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.52.0.tgz",
+      "integrity": "sha512-uh6W7sb55hl7D6vsAeA+V2p5JnlAqzhqFyF0VcJkKZXkgnFcVG9PziERRHQfPLfNGx1C292a4JqbWzhR8L4R1g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.52.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@polka/url": {
@@ -5141,6 +5159,19 @@
         "node": ">=12"
       }
     },
+    "node_modules/dotenv": {
+      "version": "16.5.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.5.0.tgz",
+      "integrity": "sha512-m/C+AwOAr9/W1UOIZUo232ejMNnJAJtYQjUbHoNTBNTJSvqzzDh7vnrei3o3r3m9blf6ZoDkvcw0VmozNRFJxg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -8562,13 +8593,13 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.51.1",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.51.1.tgz",
-      "integrity": "sha512-kkx+MB2KQRkyxjYPc3a0wLZZoDczmppyGJIvQ43l+aZihkaVvmu/21kiyaHeHjiFxjxNNFnUncKmcGIyOojsaw==",
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.52.0.tgz",
+      "integrity": "sha512-JAwMNMBlxJ2oD1kce4KPtMkDeKGHQstdpFPcPH3maElAXon/QZeTvtsfXmTMRyO9TslfoYOXkSsvao2nE1ilTw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.51.1"
+        "playwright-core": "1.52.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -8581,9 +8612,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.51.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.51.1.tgz",
-      "integrity": "sha512-/crRMj8+j/Nq5s8QcvegseuyeZPxpQCZb6HNk3Sos3BlZyAknRjoyJPFWkpNn8v0+P3WiwqFF8P+zQo4eqiNuw==",
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.52.0.tgz",
+      "integrity": "sha512-l2osTgLXSMeuLZOML9qYODUQoPPnUsKsb5/P6LJ2e6uPKXUdPK5WYhN4z03G+YNbWmGDY4YENauNu4ZKczreHg==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,11 @@
     "lint": "eslint .",
     "preview": "vite preview",
     "storybook": "storybook dev -p 6006",
-    "build-storybook": "storybook build"
+    "build-storybook": "storybook build",
+    "test:e2e": "playwright test",
+    "test:e2e:ui": "playwright test --ui",
+    "test:e2e:headed": "playwright test --headed",
+    "test:report": "playwright show-report"
   },
   "dependencies": {
     "@tailwindcss/vite": "^4.1.3",
@@ -32,6 +36,7 @@
   "devDependencies": {
     "@chromatic-com/storybook": "^3.2.6",
     "@eslint/js": "^9.17.0",
+    "@playwright/test": "^1.52.0",
     "@storybook/addon-designs": "^8.2.1",
     "@storybook/addon-essentials": "^8.6.12",
     "@storybook/addon-onboarding": "^8.6.12",
@@ -48,6 +53,7 @@
     "@vitejs/plugin-react": "^4.3.4",
     "@vitest/browser": "^3.1.1",
     "@vitest/coverage-v8": "^3.1.1",
+    "dotenv": "^16.5.0",
     "eslint": "^8.57.1",
     "eslint-config-prettier": "^10.1.2",
     "eslint-plugin-import": "^2.31.0",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,42 @@
+import { defineConfig, devices } from "@playwright/test";
+import path from "path";
+import dotenv from "dotenv";
+import process from "process";
+
+dotenv.config();
+dotenv.config({ path: ".env.production" });
+
+const isCI = !!process.env.CI;
+
+export default defineConfig({
+  testDir: "./tests",
+  fullyParallel: true,
+  forbidOnly: false,
+  retries: isCI ? 2 : 0,
+  workers: isCI ? 1 : undefined,
+  reporter: "html",
+  globalSetup: path.resolve("./tests/global-setup.ts"),
+
+  use: {
+    baseURL: "http://localhost:3000",
+    trace: "on-first-retry",
+    storageState: "tests/auth.json",
+  },
+
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+
+  ...(isCI
+    ? {}
+    : {
+        webServer: {
+          command: "npm run dev",
+          url: "http://localhost:3000",
+          reuseExistingServer: true,
+        },
+      }),
+});

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,10 +1,6 @@
 import { defineConfig, devices } from "@playwright/test";
 import path from "path";
-import dotenv from "dotenv";
 import process from "process";
-
-dotenv.config();
-dotenv.config({ path: ".env.production" });
 
 const isCI = !!process.env.CI;
 
@@ -18,7 +14,7 @@ export default defineConfig({
   globalSetup: path.resolve("./tests/global-setup.ts"),
 
   use: {
-    baseURL: "http://localhost:3000",
+    baseURL: `${isCI ? process.env.VITE_DNS_URL : "http://localhost:3000"}`,
     trace: "on-first-retry",
     storageState: "tests/auth.json",
   },

--- a/tests/LoginFlow.spec.ts
+++ b/tests/LoginFlow.spec.ts
@@ -1,0 +1,17 @@
+import test, { expect } from "playwright/test";
+
+test.describe("로그인 테스트", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/onboarding");
+  });
+
+  test("발급받은 관리자 계정으로 로그인을 진행하면, 팝업 리스트 페이지로 이동된다.", async ({
+    page,
+  }) => {
+    await page.getByPlaceholder("아이디를 입력해주세요").fill("manager1");
+    await page.getByPlaceholder("비밀번호를 입력해주세요").fill("password1");
+    await page.getByRole("button", { name: "login" }).click();
+
+    await expect(page).toHaveURL("/popup-list");
+  });
+});

--- a/tests/global-setup.ts
+++ b/tests/global-setup.ts
@@ -1,0 +1,35 @@
+import { chromium, FullConfig } from "@playwright/test";
+import fs from "fs";
+import process from "process";
+
+async function globalSetup(config: FullConfig) {
+  const authFile = "tests/auth.json";
+
+  if (fs.existsSync(authFile) && !process.env.CI) {
+    return;
+  }
+
+  const browser = await chromium.launch();
+  const page = await browser.newPage();
+
+  const baseURL = config.projects?.[0]?.use?.baseURL;
+
+  try {
+    await page.goto(`${baseURL}/onboarding`);
+    await page.waitForSelector('input[placeholder*="아이디를 입력해주세요"]', {
+      timeout: 10000,
+    });
+
+    await page.getByPlaceholder("아이디를 입력해주세요").fill("manager1");
+    await page.getByPlaceholder("비밀번호를 입력해주세요").fill("password1");
+    await page.click('button:has-text("login")');
+
+    await page.waitForTimeout(3000);
+
+    await page.context().storageState({ path: authFile });
+  } finally {
+    await browser.close();
+  }
+}
+
+export default globalSetup;

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -34,6 +34,8 @@
     ".storybook/main.ts",
     "vitest.storybook.config.ts",
     "vitest.config.ts",
-    "eslint.config.js"
+    "eslint.config.js",
+    "playwright.config.ts",
+    "tests/**/*.ts"
   ]
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,7 +3,6 @@ import react from "@vitejs/plugin-react";
 import { fileURLToPath } from "url";
 import path from "path";
 import tailwindcss from "@tailwindcss/vite";
-// import fs from "fs";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -18,10 +17,4 @@ export default defineConfig({
       "@": path.resolve(__dirname, "./src"),
     },
   },
-  // server: {
-  //   https: {
-  //     key: fs.readFileSync("localhost+1-key.pem"),
-  //     cert: fs.readFileSync("localhost+1.pem"),
-  //   },
-  // },
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -9,6 +9,14 @@ export default mergeConfig(
       globals: true,
       environment: "jsdom",
       setupFiles: ["./src/setupTests.ts"],
+      exclude: [
+        "**/node_modules/**",
+        "**/dist/**",
+        "**/tests/**",
+        "**/*.spec.ts",
+        "**/playwright-report/**",
+        "**/test-results/**",
+      ],
     },
   }),
 );


### PR DESCRIPTION
## 🌱 관련 이슈

- [LCR-299]

---

## 📌 작업 내용 및 특이사항

- Playwright 설정 추가했습니다.
- 로그인의 경우 GlobalStub으로 처리될 수 있도록 설정 추가했습니다.
    - 로컬환경에서 e2e 테스트 진행시 `tests/auth.json` 파일이 생성됩니다.
    - 매니저의 경우에는 로그인 이후 테스트가 필요하기 때문에, e2e 테스트를 진행할때마다 로그인 테스트 코드를 작성하지 않기위해 추가했습니다.
- CI 추가했습니다.
    -  CI의 경우 실제 개발 서버 API를 호출하기 때문에, 앞으로 develop 브랜치에 Merge하는 경우 개발 서버가 다운되어있으면 실패하게 됩니다.

---

## 📚 참고사항

-


[LCR-299]: https://lgcns-retail.atlassian.net/browse/LCR-299?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ