### PR TITLE
feat: 발주 내역 페이지 구현

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,8 +1,10 @@
 import { defineConfig, devices } from "@playwright/test";
 import path from "path";
 import process from "process";
+import dotenv from "dotenv";
 
 const isCI = !!process.env.CI;
+dotenv.config();
 
 export default defineConfig({
   testDir: "./tests",

--- a/src/apis/OrderListApi.ts
+++ b/src/apis/OrderListApi.ts
@@ -1,0 +1,16 @@
+import { ApiResponse, GetOrderListResponse } from "@/types/api/ApiResponseType";
+import { api } from "./config/Axios";
+import { GetOrderListRequest } from "@/types/api/ApiRequestType";
+
+export const getOrderList = async ({
+  lastId,
+  size,
+}: GetOrderListRequest): ApiResponse<GetOrderListResponse> => {
+  const response = await api.get("/orderItems/", {
+    params: {
+      ...(lastId && { lastId }),
+      size: size || 10,
+    },
+  });
+  return response.data;
+};

--- a/src/apis/OrderListApi.ts
+++ b/src/apis/OrderListApi.ts
@@ -1,16 +1,35 @@
-import { ApiResponse, GetOrderListResponse } from "@/types/api/ApiResponseType";
+import {
+  ApiResponse,
+  GetOrderListResponse,
+  NoResponse,
+} from "@/types/api/ApiResponseType";
 import { api } from "./config/Axios";
-import { GetOrderListRequest } from "@/types/api/ApiRequestType";
+import {
+  GetOrderListRequest,
+  PostChangeOrderItemRequest,
+} from "@/types/api/ApiRequestType";
 
 export const getOrderList = async ({
-  lastId,
+  lastOrderItemId,
   size,
 }: GetOrderListRequest): ApiResponse<GetOrderListResponse> => {
-  const response = await api.get("/orderItems/", {
+  const response = await api.get("/order-items/", {
     params: {
-      ...(lastId && { lastId }),
+      ...(lastOrderItemId && { lastOrderItemId }),
       size: size || 10,
     },
+  });
+  return response.data;
+};
+
+export const postChangeOrderItemStatus = async ({
+  orderItemId,
+  qty,
+  status,
+}: PostChangeOrderItemRequest): ApiResponse<NoResponse> => {
+  const response = await api.post(`/order-items/status/${orderItemId}`, {
+    qty,
+    status,
   });
   return response.data;
 };

--- a/src/components/layouts/GlobalLayout.tsx
+++ b/src/components/layouts/GlobalLayout.tsx
@@ -15,8 +15,6 @@ export default function GlobalLayout() {
     return <Navigate to="/onBoarding" replace />;
   }
 
-  console.log(isContainNavBar);
-
   return (
     <div className="box-border min-h-screen flex flex-col">
       {isContainNavBar && <NavBar />}

--- a/src/constants/NavigationItems.ts
+++ b/src/constants/NavigationItems.ts
@@ -7,4 +7,8 @@ export const NavigationItems = [
     title: "상품관리",
     url: "/items",
   },
+  {
+    title: "발주관리",
+    url: "/order-list",
+  },
 ];

--- a/src/hooks/api/useOrderListApi.ts
+++ b/src/hooks/api/useOrderListApi.ts
@@ -1,0 +1,20 @@
+import { getOrderList } from "@/apis/OrderListApi";
+import { useInfiniteQuery } from "@tanstack/react-query";
+
+export const useGetOrderListApi = ({ size }: { size: number }) => {
+  return useInfiniteQuery({
+    queryKey: ["orderItem"],
+    queryFn: ({ pageParam }) => getOrderList({ lastId: pageParam, size }),
+    getNextPageParam: response => {
+      const lastPage = response.data;
+
+      if (lastPage.isLast) {
+        return undefined;
+      }
+
+      const lastItem = lastPage.content[lastPage.content.length - 1];
+      return lastItem.orderId;
+    },
+    initialPageParam: undefined as string | undefined,
+  });
+};

--- a/src/hooks/api/useOrderListApi.ts
+++ b/src/hooks/api/useOrderListApi.ts
@@ -1,10 +1,16 @@
-import { getOrderList } from "@/apis/OrderListApi";
-import { useInfiniteQuery } from "@tanstack/react-query";
+import { getOrderList, postChangeOrderItemStatus } from "@/apis/OrderListApi";
+import { PostChangeOrderItemRequest } from "@/types/api/ApiRequestType";
+import {
+  useInfiniteQuery,
+  useMutation,
+  useQueryClient,
+} from "@tanstack/react-query";
 
 export const useGetOrderListApi = ({ size }: { size: number }) => {
   return useInfiniteQuery({
     queryKey: ["orderItem"],
-    queryFn: ({ pageParam }) => getOrderList({ lastId: pageParam, size }),
+    queryFn: ({ pageParam }) =>
+      getOrderList({ lastOrderItemId: pageParam, size }),
     getNextPageParam: response => {
       const lastPage = response.data;
 
@@ -13,8 +19,17 @@ export const useGetOrderListApi = ({ size }: { size: number }) => {
       }
 
       const lastItem = lastPage.content[lastPage.content.length - 1];
-      return lastItem.orderId;
+      return lastItem.orderItemId;
     },
-    initialPageParam: undefined as string | undefined,
+    initialPageParam: undefined as number | undefined,
+  });
+};
+
+export const usePostChangeOrderItemStatus = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({ orderItemId, qty, status }: PostChangeOrderItemRequest) =>
+      postChangeOrderItemStatus({ orderItemId, qty, status }),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ["orderItem"] }),
   });
 };

--- a/src/mocks/browser.ts
+++ b/src/mocks/browser.ts
@@ -16,6 +16,7 @@ import { BestItemsHandlers } from "./handlers/dashboard/BestItems.handlers";
 import { QuestionnaireHandlers } from "./handlers/dashboard/Questionnaire.handlers";
 import { VisitorStatsHandlers } from "./handlers/dashboard/VisitorDatas.handlers";
 import { PopUpListReadHandlers } from "./handlers/popUpListRead/PopUpListRead.handlers";
+import { OrderListHandlers } from "./handlers/orderList/OrderList.handlers";
 
 export const handlers = [
   ...AuthHandlers,
@@ -33,6 +34,7 @@ export const handlers = [
   ...QuestionnaireHandlers,
   ...ConversionReadHandlers,
   ...VisitorStatsHandlers,
+  ...OrderListHandlers,
 ];
 
 export const worker = setupWorker(...handlers);

--- a/src/mocks/handlers/orderList/OrderList.handlers.ts
+++ b/src/mocks/handlers/orderList/OrderList.handlers.ts
@@ -326,7 +326,7 @@ export const OrderListHandlers = [
     );
 
     if (itemIndex !== -1) {
-      mockOrderItems[itemIndex].status = requestBody.status as any;
+      mockOrderItems[itemIndex].status = requestBody.status;
       mockOrderItems[itemIndex].realCount = requestBody.qty;
       console.log(
         `Updated item ${orderItemId} status to ${requestBody.status}`,

--- a/src/mocks/handlers/orderList/OrderList.handlers.ts
+++ b/src/mocks/handlers/orderList/OrderList.handlers.ts
@@ -3,257 +3,257 @@ import { http, HttpResponse } from "msw";
 
 const mockOrderItems = [
   {
-    orderId: "ORD-2025-001",
+    orderItemId: 1,
     itemName: "프리미엄 원두커피",
-    recommendQuantity: 50,
-    realQuantity: 45,
-    lastUpdated: "2025-06-03T14:30:00Z",
-    state: "PENDING",
+    recommendCount: 50,
+    realCount: 45,
+    lastRestockDate: "2025-06-03T14:30:00Z",
+    status: "PENDING",
   },
   {
-    orderId: "ORD-2025-002",
+    orderItemId: 2,
     itemName: "유기농 우유",
-    recommendQuantity: 100,
-    realQuantity: 95,
-    lastUpdated: "2025-06-03T13:15:00Z",
-    state: "CONFIRMED",
+    recommendCount: 100,
+    realCount: 95,
+    lastRestockDate: "2025-06-03T13:15:00Z",
+    status: "COMPLETED",
   },
   {
-    orderId: "ORD-2025-003",
+    orderItemId: 3,
     itemName: "신선한 샐러드",
-    recommendQuantity: 30,
-    realQuantity: 28,
-    lastUpdated: "2025-06-03T12:45:00Z",
-    state: "CONFIRMED",
+    recommendCount: 30,
+    realCount: 28,
+    lastRestockDate: "2025-06-03T12:45:00Z",
+    status: "COMPLETED",
   },
   {
-    orderId: "ORD-2025-004",
+    orderItemId: 4,
     itemName: "프로틴 바",
-    recommendQuantity: 80,
-    realQuantity: 75,
-    lastUpdated: "2025-06-03T11:20:00Z",
-    state: "PENDING",
+    recommendCount: 80,
+    realCount: 75,
+    lastRestockDate: "2025-06-03T11:20:00Z",
+    status: "PENDING",
   },
   {
-    orderId: "ORD-2025-005",
+    orderItemId: 5,
     itemName: "천연 주스",
-    recommendQuantity: 60,
-    realQuantity: 58,
-    lastUpdated: "2025-06-03T10:10:00Z",
-    state: "CONFIRMED",
+    recommendCount: 60,
+    realCount: 58,
+    lastRestockDate: "2025-06-03T10:10:00Z",
+    status: "COMPLETED",
   },
   {
-    orderId: "ORD-2025-006",
+    orderItemId: 6,
     itemName: "글루텐프리 빵",
-    recommendQuantity: 40,
-    realQuantity: 35,
-    lastUpdated: "2025-06-03T09:30:00Z",
-    state: "CANCELLED",
+    recommendCount: 40,
+    realCount: 35,
+    lastRestockDate: "2025-06-03T09:30:00Z",
+    status: "CANCELLED",
   },
   {
-    orderId: "ORD-2025-007",
+    orderItemId: 7,
     itemName: "아이스크림",
-    recommendQuantity: 25,
-    realQuantity: 20,
-    lastUpdated: "2025-06-03T08:45:00Z",
-    state: "CONFIRMED",
+    recommendCount: 25,
+    realCount: 20,
+    lastRestockDate: "2025-06-03T08:45:00Z",
+    status: "COMPLETED",
   },
   {
-    orderId: "ORD-2025-008",
+    orderItemId: 8,
     itemName: "에너지 드링크",
-    recommendQuantity: 90,
-    realQuantity: 85,
-    lastUpdated: "2025-06-03T07:15:00Z",
-    state: "PENDING",
+    recommendCount: 90,
+    realCount: 85,
+    lastRestockDate: "2025-06-03T07:15:00Z",
+    status: "PENDING",
   },
   {
-    orderId: "ORD-2025-009",
+    orderItemId: 9,
     itemName: "베이글",
-    recommendQuantity: 35,
-    realQuantity: 30,
-    lastUpdated: "2025-06-03T06:30:00Z",
-    state: "CONFIRMED",
+    recommendCount: 35,
+    realCount: 30,
+    lastRestockDate: "2025-06-03T06:30:00Z",
+    status: "COMPLETED",
   },
   {
-    orderId: "ORD-2025-010",
+    orderItemId: 10,
     itemName: "그릭 요거트",
-    recommendQuantity: 70,
-    realQuantity: 70,
-    lastUpdated: "2025-06-03T05:45:00Z",
-    state: "CONFIRMED",
+    recommendCount: 70,
+    realCount: 70,
+    lastRestockDate: "2025-06-03T05:45:00Z",
+    status: "COMPLETED",
   },
   {
-    orderId: "ORD-2025-011",
+    orderItemId: 11,
     itemName: "아보카도",
-    recommendQuantity: 20,
-    realQuantity: 18,
-    lastUpdated: "2025-06-02T23:30:00Z",
-    state: "PENDING",
+    recommendCount: 20,
+    realCount: 18,
+    lastRestockDate: "2025-06-02T23:30:00Z",
+    status: "PENDING",
   },
   {
-    orderId: "ORD-2025-012",
+    orderItemId: 12,
     itemName: "스무디 믹스",
-    recommendQuantity: 45,
-    realQuantity: 40,
-    lastUpdated: "2025-06-02T22:15:00Z",
-    state: "CONFIRMED",
+    recommendCount: 45,
+    realCount: 40,
+    lastRestockDate: "2025-06-02T22:15:00Z",
+    status: "COMPLETED",
   },
   {
-    orderId: "ORD-2025-013",
+    orderItemId: 13,
     itemName: "치아시드",
-    recommendQuantity: 15,
-    realQuantity: 15,
-    lastUpdated: "2025-06-02T21:00:00Z",
-    state: "CONFIRMED",
+    recommendCount: 15,
+    realCount: 15,
+    lastRestockDate: "2025-06-02T21:00:00Z",
+    status: "COMPLETED",
   },
   {
-    orderId: "ORD-2025-014",
+    orderItemId: 14,
     itemName: "견과류 믹스",
-    recommendQuantity: 55,
-    realQuantity: 50,
-    lastUpdated: "2025-06-02T20:30:00Z",
-    state: "PENDING",
+    recommendCount: 55,
+    realCount: 50,
+    lastRestockDate: "2025-06-02T20:30:00Z",
+    status: "PENDING",
   },
   {
-    orderId: "ORD-2025-015",
+    orderItemId: 15,
     itemName: "코코넛 워터",
-    recommendQuantity: 80,
-    realQuantity: 85,
-    lastUpdated: "2025-06-02T19:45:00Z",
-    state: "CONFIRMED",
+    recommendCount: 80,
+    realCount: 85,
+    lastRestockDate: "2025-06-02T19:45:00Z",
+    status: "COMPLETED",
   },
   {
-    orderId: "ORD-2025-016",
+    orderItemId: 16,
     itemName: "퀴노아",
-    recommendQuantity: 25,
-    realQuantity: 22,
-    lastUpdated: "2025-06-02T18:20:00Z",
-    state: "CONFIRMED",
+    recommendCount: 25,
+    realCount: 22,
+    lastRestockDate: "2025-06-02T18:20:00Z",
+    status: "COMPLETED",
   },
   {
-    orderId: "ORD-2025-017",
+    orderItemId: 17,
     itemName: "올리브오일",
-    recommendQuantity: 12,
-    realQuantity: 10,
-    lastUpdated: "2025-06-02T17:15:00Z",
-    state: "CANCELLED",
+    recommendCount: 12,
+    realCount: 10,
+    lastRestockDate: "2025-06-02T17:15:00Z",
+    status: "CANCELLED",
   },
   {
-    orderId: "ORD-2025-018",
+    orderItemId: 18,
     itemName: "허브 티",
-    recommendQuantity: 40,
-    realQuantity: 38,
-    lastUpdated: "2025-06-02T16:30:00Z",
-    state: "PENDING",
+    recommendCount: 40,
+    realCount: 38,
+    lastRestockDate: "2025-06-02T16:30:00Z",
+    status: "PENDING",
   },
   {
-    orderId: "ORD-2025-019",
+    orderItemId: 19,
     itemName: "다크 초콜릿",
-    recommendQuantity: 60,
-    realQuantity: 55,
-    lastUpdated: "2025-06-02T15:45:00Z",
-    state: "CONFIRMED",
+    recommendCount: 60,
+    realCount: 55,
+    lastRestockDate: "2025-06-02T15:45:00Z",
+    status: "COMPLETED",
   },
   {
-    orderId: "ORD-2025-020",
+    orderItemId: 20,
     itemName: "현미",
-    recommendQuantity: 95,
-    realQuantity: 90,
-    lastUpdated: "2025-06-02T14:20:00Z",
-    state: "CONFIRMED",
+    recommendCount: 95,
+    realCount: 90,
+    lastRestockDate: "2025-06-02T14:20:00Z",
+    status: "COMPLETED",
   },
   {
-    orderId: "ORD-2025-021",
+    orderItemId: 21,
     itemName: "두부",
-    recommendQuantity: 30,
-    realQuantity: 28,
-    lastUpdated: "2025-06-02T13:10:00Z",
-    state: "PENDING",
+    recommendCount: 30,
+    realCount: 28,
+    lastRestockDate: "2025-06-02T13:10:00Z",
+    status: "PENDING",
   },
   {
-    orderId: "ORD-2025-022",
+    orderItemId: 22,
     itemName: "연어",
-    recommendQuantity: 18,
-    realQuantity: 15,
-    lastUpdated: "2025-06-02T12:30:00Z",
-    state: "CONFIRMED",
+    recommendCount: 18,
+    realCount: 15,
+    lastRestockDate: "2025-06-02T12:30:00Z",
+    status: "COMPLETED",
   },
   {
-    orderId: "ORD-2025-023",
+    orderItemId: 23,
     itemName: "브로콜리",
-    recommendQuantity: 45,
-    realQuantity: 42,
-    lastUpdated: "2025-06-02T11:45:00Z",
-    state: "CONFIRMED",
+    recommendCount: 45,
+    realCount: 42,
+    lastRestockDate: "2025-06-02T11:45:00Z",
+    status: "COMPLETED",
   },
   {
-    orderId: "ORD-2025-024",
+    orderItemId: 24,
     itemName: "레몬",
-    recommendQuantity: 35,
-    realQuantity: 30,
-    lastUpdated: "2025-06-02T10:20:00Z",
-    state: "PENDING",
+    recommendCount: 35,
+    realCount: 30,
+    lastRestockDate: "2025-06-02T10:20:00Z",
+    status: "PENDING",
   },
   {
-    orderId: "ORD-2025-025",
+    orderItemId: 25,
     itemName: "생강",
-    recommendQuantity: 10,
-    realQuantity: 8,
-    lastUpdated: "2025-06-02T09:15:00Z",
-    state: "CONFIRMED",
+    recommendCount: 10,
+    realCount: 8,
+    lastRestockDate: "2025-06-02T09:15:00Z",
+    status: "COMPLETED",
   },
   {
-    orderId: "ORD-2025-026",
+    orderItemId: 26,
     itemName: "마카다미아",
-    recommendQuantity: 22,
-    realQuantity: 20,
-    lastUpdated: "2025-06-02T08:30:00Z",
-    state: "CANCELLED",
+    recommendCount: 22,
+    realCount: 20,
+    lastRestockDate: "2025-06-02T08:30:00Z",
+    status: "CANCELLED",
   },
   {
-    orderId: "ORD-2025-027",
+    orderItemId: 27,
     itemName: "코코아 파우더",
-    recommendQuantity: 15,
-    realQuantity: 15,
-    lastUpdated: "2025-06-02T07:45:00Z",
-    state: "CONFIRMED",
+    recommendCount: 15,
+    realCount: 15,
+    lastRestockDate: "2025-06-02T07:45:00Z",
+    status: "COMPLETED",
   },
   {
-    orderId: "ORD-2025-028",
+    orderItemId: 28,
     itemName: "메이플 시럽",
-    recommendQuantity: 28,
-    realQuantity: 25,
-    lastUpdated: "2025-06-02T06:20:00Z",
-    state: "PENDING",
+    recommendCount: 28,
+    realCount: 25,
+    lastRestockDate: "2025-06-02T06:20:00Z",
+    status: "PENDING",
   },
   {
-    orderId: "ORD-2025-029",
+    orderItemId: 29,
     itemName: "콤부차",
-    recommendQuantity: 50,
-    realQuantity: 48,
-    lastUpdated: "2025-06-02T05:10:00Z",
-    state: "CONFIRMED",
+    recommendCount: 50,
+    realCount: 48,
+    lastRestockDate: "2025-06-02T05:10:00Z",
+    status: "COMPLETED",
   },
   {
-    orderId: "ORD-2025-030",
+    orderItemId: 30,
     itemName: "캐슈넛",
-    recommendQuantity: 40,
-    realQuantity: 35,
-    lastUpdated: "2025-06-02T04:30:00Z",
-    state: "CONFIRMED",
+    recommendCount: 40,
+    realCount: 35,
+    lastRestockDate: "2025-06-02T04:30:00Z",
+    status: "COMPLETED",
   },
 ];
 
 export const OrderListHandlers = [
-  http.get("/orderItems", async ({ request }) => {
+  http.get("/order-items", async ({ request }) => {
     const url = new URL(request.url);
-    const lastId = url.searchParams.get("lastId");
+    const lastOrderItemId = url.searchParams.get("lastOrderItemId");
     const size = parseInt(url.searchParams.get("size") || "10");
 
     let startIndex = 0;
-    if (lastId) {
+    if (lastOrderItemId) {
       const lastIndex = mockOrderItems.findIndex(
-        item => item.orderId === lastId,
+        item => item.orderItemId === Number(lastOrderItemId),
       );
       startIndex = lastIndex >= 0 ? lastIndex + 1 : 0;
     }
@@ -261,7 +261,9 @@ export const OrderListHandlers = [
     const content = mockOrderItems.slice(startIndex, startIndex + size);
     const isLast = startIndex + size >= mockOrderItems.length;
 
-    console.log(`Order List Request - lastId: ${lastId}, size: ${size}`);
+    console.log(
+      `Order List Request - lastOrderItemId: ${lastOrderItemId}, size: ${size}`,
+    );
     console.log(`Returning ${content.length} items, isLast: ${isLast}`);
 
     return HttpResponse.json(
@@ -272,6 +274,70 @@ export const OrderListHandlers = [
           content,
           isLast,
         } as GetOrderListResponse,
+        timestamp: new Date().toISOString(),
+      },
+      { status: 200 },
+    );
+  }),
+
+  http.post("/order-items/status/:orderItemId", async ({ request, params }) => {
+    const { orderItemId } = params;
+    const requestBody = (await request.json()) as {
+      qty: number;
+      status: string;
+    };
+
+    console.log(`Status Change Request - orderItemId: ${orderItemId}`);
+    console.log(`Request body:`, requestBody);
+
+    const itemExists = mockOrderItems.find(
+      item => item.orderItemId === Number(orderItemId),
+    );
+
+    if (!itemExists) {
+      return HttpResponse.json(
+        {
+          success: false,
+          status: 404,
+          data: null,
+          timestamp: new Date().toISOString(),
+          error: "Order item not found",
+        },
+        { status: 404 },
+      );
+    }
+
+    const validStatuses = ["COMPLETED", "CANCELLED"];
+    if (!validStatuses.includes(requestBody.status)) {
+      return HttpResponse.json(
+        {
+          success: false,
+          status: 400,
+          data: null,
+          timestamp: new Date().toISOString(),
+          error: "Invalid status value",
+        },
+        { status: 400 },
+      );
+    }
+
+    const itemIndex = mockOrderItems.findIndex(
+      item => item.orderItemId === Number(orderItemId),
+    );
+
+    if (itemIndex !== -1) {
+      mockOrderItems[itemIndex].status = requestBody.status as any;
+      mockOrderItems[itemIndex].realCount = requestBody.qty;
+      console.log(
+        `Updated item ${orderItemId} status to ${requestBody.status}`,
+      );
+    }
+
+    return HttpResponse.json(
+      {
+        success: true,
+        status: 200,
+        data: null,
         timestamp: new Date().toISOString(),
       },
       { status: 200 },

--- a/src/mocks/handlers/orderList/OrderList.handlers.ts
+++ b/src/mocks/handlers/orderList/OrderList.handlers.ts
@@ -1,0 +1,280 @@
+import { GetOrderListResponse } from "@/types/api/ApiResponseType";
+import { http, HttpResponse } from "msw";
+
+const mockOrderItems = [
+  {
+    orderId: "ORD-2025-001",
+    itemName: "프리미엄 원두커피",
+    recommendQuantity: 50,
+    realQuantity: 45,
+    lastUpdated: "2025-06-03T14:30:00Z",
+    state: "PENDING",
+  },
+  {
+    orderId: "ORD-2025-002",
+    itemName: "유기농 우유",
+    recommendQuantity: 100,
+    realQuantity: 95,
+    lastUpdated: "2025-06-03T13:15:00Z",
+    state: "CONFIRMED",
+  },
+  {
+    orderId: "ORD-2025-003",
+    itemName: "신선한 샐러드",
+    recommendQuantity: 30,
+    realQuantity: 28,
+    lastUpdated: "2025-06-03T12:45:00Z",
+    state: "CONFIRMED",
+  },
+  {
+    orderId: "ORD-2025-004",
+    itemName: "프로틴 바",
+    recommendQuantity: 80,
+    realQuantity: 75,
+    lastUpdated: "2025-06-03T11:20:00Z",
+    state: "PENDING",
+  },
+  {
+    orderId: "ORD-2025-005",
+    itemName: "천연 주스",
+    recommendQuantity: 60,
+    realQuantity: 58,
+    lastUpdated: "2025-06-03T10:10:00Z",
+    state: "CONFIRMED",
+  },
+  {
+    orderId: "ORD-2025-006",
+    itemName: "글루텐프리 빵",
+    recommendQuantity: 40,
+    realQuantity: 35,
+    lastUpdated: "2025-06-03T09:30:00Z",
+    state: "CANCELLED",
+  },
+  {
+    orderId: "ORD-2025-007",
+    itemName: "아이스크림",
+    recommendQuantity: 25,
+    realQuantity: 20,
+    lastUpdated: "2025-06-03T08:45:00Z",
+    state: "CONFIRMED",
+  },
+  {
+    orderId: "ORD-2025-008",
+    itemName: "에너지 드링크",
+    recommendQuantity: 90,
+    realQuantity: 85,
+    lastUpdated: "2025-06-03T07:15:00Z",
+    state: "PENDING",
+  },
+  {
+    orderId: "ORD-2025-009",
+    itemName: "베이글",
+    recommendQuantity: 35,
+    realQuantity: 30,
+    lastUpdated: "2025-06-03T06:30:00Z",
+    state: "CONFIRMED",
+  },
+  {
+    orderId: "ORD-2025-010",
+    itemName: "그릭 요거트",
+    recommendQuantity: 70,
+    realQuantity: 70,
+    lastUpdated: "2025-06-03T05:45:00Z",
+    state: "CONFIRMED",
+  },
+  {
+    orderId: "ORD-2025-011",
+    itemName: "아보카도",
+    recommendQuantity: 20,
+    realQuantity: 18,
+    lastUpdated: "2025-06-02T23:30:00Z",
+    state: "PENDING",
+  },
+  {
+    orderId: "ORD-2025-012",
+    itemName: "스무디 믹스",
+    recommendQuantity: 45,
+    realQuantity: 40,
+    lastUpdated: "2025-06-02T22:15:00Z",
+    state: "CONFIRMED",
+  },
+  {
+    orderId: "ORD-2025-013",
+    itemName: "치아시드",
+    recommendQuantity: 15,
+    realQuantity: 15,
+    lastUpdated: "2025-06-02T21:00:00Z",
+    state: "CONFIRMED",
+  },
+  {
+    orderId: "ORD-2025-014",
+    itemName: "견과류 믹스",
+    recommendQuantity: 55,
+    realQuantity: 50,
+    lastUpdated: "2025-06-02T20:30:00Z",
+    state: "PENDING",
+  },
+  {
+    orderId: "ORD-2025-015",
+    itemName: "코코넛 워터",
+    recommendQuantity: 80,
+    realQuantity: 85,
+    lastUpdated: "2025-06-02T19:45:00Z",
+    state: "CONFIRMED",
+  },
+  {
+    orderId: "ORD-2025-016",
+    itemName: "퀴노아",
+    recommendQuantity: 25,
+    realQuantity: 22,
+    lastUpdated: "2025-06-02T18:20:00Z",
+    state: "CONFIRMED",
+  },
+  {
+    orderId: "ORD-2025-017",
+    itemName: "올리브오일",
+    recommendQuantity: 12,
+    realQuantity: 10,
+    lastUpdated: "2025-06-02T17:15:00Z",
+    state: "CANCELLED",
+  },
+  {
+    orderId: "ORD-2025-018",
+    itemName: "허브 티",
+    recommendQuantity: 40,
+    realQuantity: 38,
+    lastUpdated: "2025-06-02T16:30:00Z",
+    state: "PENDING",
+  },
+  {
+    orderId: "ORD-2025-019",
+    itemName: "다크 초콜릿",
+    recommendQuantity: 60,
+    realQuantity: 55,
+    lastUpdated: "2025-06-02T15:45:00Z",
+    state: "CONFIRMED",
+  },
+  {
+    orderId: "ORD-2025-020",
+    itemName: "현미",
+    recommendQuantity: 95,
+    realQuantity: 90,
+    lastUpdated: "2025-06-02T14:20:00Z",
+    state: "CONFIRMED",
+  },
+  {
+    orderId: "ORD-2025-021",
+    itemName: "두부",
+    recommendQuantity: 30,
+    realQuantity: 28,
+    lastUpdated: "2025-06-02T13:10:00Z",
+    state: "PENDING",
+  },
+  {
+    orderId: "ORD-2025-022",
+    itemName: "연어",
+    recommendQuantity: 18,
+    realQuantity: 15,
+    lastUpdated: "2025-06-02T12:30:00Z",
+    state: "CONFIRMED",
+  },
+  {
+    orderId: "ORD-2025-023",
+    itemName: "브로콜리",
+    recommendQuantity: 45,
+    realQuantity: 42,
+    lastUpdated: "2025-06-02T11:45:00Z",
+    state: "CONFIRMED",
+  },
+  {
+    orderId: "ORD-2025-024",
+    itemName: "레몬",
+    recommendQuantity: 35,
+    realQuantity: 30,
+    lastUpdated: "2025-06-02T10:20:00Z",
+    state: "PENDING",
+  },
+  {
+    orderId: "ORD-2025-025",
+    itemName: "생강",
+    recommendQuantity: 10,
+    realQuantity: 8,
+    lastUpdated: "2025-06-02T09:15:00Z",
+    state: "CONFIRMED",
+  },
+  {
+    orderId: "ORD-2025-026",
+    itemName: "마카다미아",
+    recommendQuantity: 22,
+    realQuantity: 20,
+    lastUpdated: "2025-06-02T08:30:00Z",
+    state: "CANCELLED",
+  },
+  {
+    orderId: "ORD-2025-027",
+    itemName: "코코아 파우더",
+    recommendQuantity: 15,
+    realQuantity: 15,
+    lastUpdated: "2025-06-02T07:45:00Z",
+    state: "CONFIRMED",
+  },
+  {
+    orderId: "ORD-2025-028",
+    itemName: "메이플 시럽",
+    recommendQuantity: 28,
+    realQuantity: 25,
+    lastUpdated: "2025-06-02T06:20:00Z",
+    state: "PENDING",
+  },
+  {
+    orderId: "ORD-2025-029",
+    itemName: "콤부차",
+    recommendQuantity: 50,
+    realQuantity: 48,
+    lastUpdated: "2025-06-02T05:10:00Z",
+    state: "CONFIRMED",
+  },
+  {
+    orderId: "ORD-2025-030",
+    itemName: "캐슈넛",
+    recommendQuantity: 40,
+    realQuantity: 35,
+    lastUpdated: "2025-06-02T04:30:00Z",
+    state: "CONFIRMED",
+  },
+];
+
+export const OrderListHandlers = [
+  http.get("/orderItems", async ({ request }) => {
+    const url = new URL(request.url);
+    const lastId = url.searchParams.get("lastId");
+    const size = parseInt(url.searchParams.get("size") || "10");
+
+    let startIndex = 0;
+    if (lastId) {
+      const lastIndex = mockOrderItems.findIndex(
+        item => item.orderId === lastId,
+      );
+      startIndex = lastIndex >= 0 ? lastIndex + 1 : 0;
+    }
+
+    const content = mockOrderItems.slice(startIndex, startIndex + size);
+    const isLast = startIndex + size >= mockOrderItems.length;
+
+    console.log(`Order List Request - lastId: ${lastId}, size: ${size}`);
+    console.log(`Returning ${content.length} items, isLast: ${isLast}`);
+
+    return HttpResponse.json(
+      {
+        success: true,
+        status: 200,
+        data: {
+          content,
+          isLast,
+        } as GetOrderListResponse,
+        timestamp: new Date().toISOString(),
+      },
+      { status: 200 },
+    );
+  }),
+];

--- a/src/pages/orderListPage/OrderListPage.tsx
+++ b/src/pages/orderListPage/OrderListPage.tsx
@@ -1,0 +1,136 @@
+import { useGetOrderListApi } from "@/hooks/api/useOrderListApi";
+
+export default function OrderListPage() {
+  const { data, fetchNextPage, hasNextPage, isFetchingNextPage } =
+    useGetOrderListApi({ size: 5 });
+  const orderList = data?.pages.flatMap(item => item.data.content);
+
+  const getStateText = (state: string) => {
+    switch (state) {
+      case "PENDING":
+        return (
+          <div className="flex w-full justify-center gap-2">
+            <button className="cursor-pointer px-4 py-2 border rounded-full bg-gray10 text-gray01 hover:bg-gray08">
+              승인
+            </button>
+            <button className="cursor-pointer px-4 py-2 border rounded-full hover:bg-gray03">
+              취소
+            </button>
+          </div>
+        );
+      case "CONFIRMED":
+        return <span>완료</span>;
+      case "CANCELLED":
+        return <span>취소</span>;
+      default:
+        return state;
+    }
+  };
+
+  const formatDate = (dateString: string) => {
+    const date = new Date(dateString);
+    return date.toLocaleString("ko-KR", {
+      year: "numeric",
+      month: "2-digit",
+      day: "2-digit",
+      hour: "2-digit",
+      minute: "2-digit",
+      hour12: false,
+    });
+  };
+
+  return (
+    <div className="min-h-screen p-6">
+      <div className="bg-gray01 rounded-lg border border-gray04 overflow-hidden">
+        <div className="px-6 py-4 border-b border-gray04">
+          <h2 className="text-3xl font-semibold text-gray10">주문 목록</h2>
+        </div>
+
+        <div className="overflow-x-auto">
+          <table className="w-full">
+            <thead>
+              <tr className="bg-gray02 border-b border-gray04">
+                <th className="px-6 py-4 text-left text-xl font-medium text-gray10 uppercase">
+                  번호
+                </th>
+                <th className="px-6 py-4 text-left text-xl font-medium text-gray10 uppercase">
+                  상품명
+                </th>
+                <th className="px-6 py-4 text-center text-xl font-medium text-gray10 uppercase">
+                  추천 개수
+                </th>
+                <th className="px-6 py-4 text-center text-xl font-medium text-gray10 uppercase">
+                  실제 발주 개수
+                </th>
+                <th className="px-6 py-4 text-center text-xl font-medium text-gray10 uppercase">
+                  최근 입고일시
+                </th>
+                <th className="px-6 py-4 text-center text-xl font-medium text-gray10 uppercase">
+                  상태
+                </th>
+              </tr>
+            </thead>
+            <tbody className="bg-gray01 divide-y divide-gray04">
+              {orderList && orderList.length > 0 ? (
+                orderList.map((item, idx) => (
+                  <tr
+                    key={idx}
+                    className="hover:bg-gray02 transition-colors duration-150"
+                  >
+                    <td className="px-6 py-4 whitespace-nowrap text-lg font-medium text-gray10">
+                      {idx + 1}
+                    </td>
+                    <td className="px-6 py-4 whitespace-nowrap">
+                      <div className="text-lg font-medium text-gray10">
+                        {item.itemName}
+                      </div>
+                    </td>
+                    <td className="px-6 py-4 whitespace-nowrap text-center">
+                      <div className="text-lg font-semibold text-gray10">
+                        {item.recommendQuantity}
+                      </div>
+                    </td>
+                    <td className="px-6 py-4 whitespace-nowrap text-center">
+                      <input
+                        className="text-lg font-semibold text-gray10 w-20 px-2 py-1 border border-gray05 rounded bg-gray01 text-center"
+                        placeholder={String(item.realQuantity)}
+                      />
+                    </td>
+                    <td className="px-6 py-4 whitespace-nowrap text-center text-lg text-gray09">
+                      {formatDate(item.lastUpdated)}
+                    </td>
+                    <td className="px-6 py-4 whitespace-nowrap text-center">
+                      {getStateText(item.state)}
+                    </td>
+                  </tr>
+                ))
+              ) : (
+                <tr>
+                  <td colSpan={6} className="px-6 py-12 text-center">
+                    <div className="text-gray08">
+                      <p className="text-sm">주문 데이터가 없습니다.</p>
+                    </div>
+                  </td>
+                </tr>
+              )}
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      <div className="mt-8 flex items-center justify-center">
+        {hasNextPage ? (
+          <button
+            onClick={() => fetchNextPage()}
+            disabled={isFetchingNextPage}
+            className="px-6 py-3 bg-main07 text-gray01 text-xl rounded-full hover:bg-main05 disabled:opacity-50"
+          >
+            {isFetchingNextPage ? "로딩 중" : "더보기"}
+          </button>
+        ) : (
+          <p className="text-gray08 text-xl">모든 주문을 확인했습니다.</p>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/pages/orderListPage/OrderListPage.tsx
+++ b/src/pages/orderListPage/OrderListPage.tsx
@@ -48,12 +48,12 @@ export default function OrderListPage() {
 
   return (
     <div className="min-h-screen p-6">
-      <div className="bg-gray01 rounded-lg border border-gray04 overflow-hidden">
-        <div className="px-6 py-4 border-b border-gray04">
+      <div className="bg-gray01 rounded-lg overflow-hidden">
+        <div className="px-6 py-4">
           <h2 className="text-3xl font-semibold text-gray10">주문 목록</h2>
         </div>
 
-        <div className="overflow-x-auto">
+        <div className="overflow-x-auto border border-gray04 rounded-lg">
           <table className="w-full">
             <colgroup className="hidden lg:table-column-group">
               <col width={100} />

--- a/src/pages/orderListPage/views/OrderListItem.tsx
+++ b/src/pages/orderListPage/views/OrderListItem.tsx
@@ -1,0 +1,105 @@
+import { OrderListItemType } from "@/types/OrderListPageType";
+import { PendingActionType } from "../OrderListPage";
+import { useState } from "react";
+
+type Props = {
+  item: OrderListItemType;
+  idx: number;
+  changePendingAction: (_request: PendingActionType) => void;
+};
+
+export default function OrderListItem({
+  item,
+  idx,
+  changePendingAction,
+}: Props) {
+  const [realCount, setRealCount] = useState<string>("");
+
+  const getStateText = (item: OrderListItemType) => {
+    switch (item.status) {
+      case "PENDING":
+        return (
+          <div className="flex w-full justify-center gap-2">
+            <button
+              className="cursor-pointer px-4 py-2 border rounded-full bg-gray10 text-gray01 hover:bg-gray08"
+              onClick={() =>
+                changePendingAction({
+                  item: { ...item, realCount: Number(realCount) },
+                  status: "COMPLETED",
+                })
+              }
+            >
+              승인
+            </button>
+            <button
+              className="cursor-pointer px-4 py-2 border rounded-full hover:bg-gray03"
+              onClick={() =>
+                changePendingAction({
+                  item: { ...item, realCount: Number(realCount) },
+                  status: "CANCELLED",
+                })
+              }
+            >
+              취소
+            </button>
+          </div>
+        );
+      case "COMPLETED":
+        return <span>완료</span>;
+      case "CANCELLED":
+        return <span>취소</span>;
+      default:
+        return status;
+    }
+  };
+
+  const formatDate = (dateString: string) => {
+    const date = new Date(dateString);
+    return date.toLocaleString("ko-KR", {
+      year: "numeric",
+      month: "2-digit",
+      day: "2-digit",
+      hour: "2-digit",
+      minute: "2-digit",
+      hour12: false,
+    });
+  };
+
+  return (
+    <tr className="hover:bg-gray02 transition-colors duration-150">
+      <td className="px-6 py-4 whitespace-nowrap text-lg font-medium text-gray10">
+        {idx + 1}
+      </td>
+      <td className="px-6 py-4 whitespace-nowrap">
+        <div className="text-lg font-medium text-gray10">{item.itemName}</div>
+      </td>
+      <td className="px-6 py-4 whitespace-nowrap text-center">
+        <div className="text-lg font-semibold text-gray10">
+          {item.recommendCount}
+        </div>
+      </td>
+      <td className="px-6 py-4 whitespace-nowrap text-center">
+        {item.status !== "PENDING" ? (
+          <div>
+            <span className="text-lg font-semibold text-gray10 w-20 px-2 py-1 ">
+              {item.realCount}
+            </span>
+          </div>
+        ) : (
+          <input
+            className="text-lg font-medium text-gray10 w-20 px-2 py-1 border border-gray07 rounded bg-gray01 text-center placeholder:text-gray07"
+            placeholder={String(item.realCount)}
+            value={realCount}
+            onChange={e => setRealCount(e.target.value)}
+          />
+        )}
+      </td>
+      <td className="px-6 py-4 whitespace-nowrap text-center text-lg text-gray09">
+        {formatDate(item.lastRestockDate)}
+      </td>
+      <td className="px-6 py-4 whitespace-nowrap text-center">
+        {getStateText(item)}
+      </td>
+    </tr>
+  );
+}

--- a/src/pages/orderListPage/views/OrderListItem.tsx
+++ b/src/pages/orderListPage/views/OrderListItem.tsx
@@ -1,6 +1,7 @@
 import { OrderListItemType } from "@/types/OrderListPageType";
 import { PendingActionType } from "../OrderListPage";
 import { useState } from "react";
+import { FormatDateTimeToString } from "@/utils/FormatDay";
 
 type Props = {
   item: OrderListItemType;
@@ -53,18 +54,6 @@ export default function OrderListItem({
     }
   };
 
-  const formatDate = (dateString: string) => {
-    const date = new Date(dateString);
-    return date.toLocaleString("ko-KR", {
-      year: "numeric",
-      month: "2-digit",
-      day: "2-digit",
-      hour: "2-digit",
-      minute: "2-digit",
-      hour12: false,
-    });
-  };
-
   return (
     <tr className="hover:bg-gray02 transition-colors duration-150">
       <td className="px-6 py-4 whitespace-nowrap text-lg font-medium text-gray10">
@@ -95,7 +84,10 @@ export default function OrderListItem({
         )}
       </td>
       <td className="px-6 py-4 whitespace-nowrap text-center text-lg text-gray09">
-        {formatDate(item.lastRestockDate)}
+        {FormatDateTimeToString(new Date(item.lastRestockDate), 24).replace(
+          "T",
+          " ",
+        )}
       </td>
       <td className="px-6 py-4 whitespace-nowrap text-center">
         {getStateText(item)}

--- a/src/pages/popUpListPage/views/PopUpCard.tsx
+++ b/src/pages/popUpListPage/views/PopUpCard.tsx
@@ -63,6 +63,7 @@ export default function PopUpCard({
       <span
         onClick={handleSelect}
         lang="en"
+        id={`popup-name-${popupId}`}
         className="cursor-pointer w-[286px] break-words block text-center justify-center text-[34px] mt-[22px]"
       >
         {isNameContainPopUp ? (

--- a/src/router/Router.tsx
+++ b/src/router/Router.tsx
@@ -4,6 +4,7 @@ import DashBoardPage from "@/pages/dashboardPage/DashBoardPage";
 import ItemCreatePage from "@/pages/itemCreatePage/ItemCreatePage";
 import ItemListPage from "@/pages/itemListPage/ItemListPage";
 import OnBoradingPage from "@/pages/onBoardingPage/OnBoardingPage";
+import OrderListPage from "@/pages/orderListPage/OrderListPage";
 import PopUpCreatePage from "@/pages/popUpCreatePage/PopUpCreatePage";
 import PopUpListPage from "@/pages/popUpListPage/PopUpListPage";
 import { createBrowserRouter } from "react-router-dom";
@@ -44,6 +45,10 @@ export const Router = createBrowserRouter([
           {
             path: "/popup-create",
             element: <PopUpCreatePage />,
+          },
+          {
+            path: "/order-list",
+            element: <OrderListPage />,
           },
         ],
       },

--- a/src/types/OrderListPageType.ts
+++ b/src/types/OrderListPageType.ts
@@ -1,8 +1,10 @@
-export type OrderListItem = {
-  orderId: string;
+export type OrderListItemType = {
+  orderItemId: number;
   itemName: string;
-  recommendQuantity: number;
-  realQuantity: number;
-  lastUpdated: string;
-  state: string;
+  recommendCount: number;
+  realCount: number;
+  lastRestockDate: string;
+  status: OrderItemStatus;
 };
+
+export type OrderItemStatus = "CANCELLED" | "COMPLETED" | "PENDING";

--- a/src/types/OrderListPageType.ts
+++ b/src/types/OrderListPageType.ts
@@ -1,0 +1,8 @@
+export type OrderListItem = {
+  orderId: string;
+  itemName: string;
+  recommendQuantity: number;
+  realQuantity: number;
+  lastUpdated: string;
+  state: string;
+};

--- a/src/types/api/ApiRequestType.ts
+++ b/src/types/api/ApiRequestType.ts
@@ -1,3 +1,5 @@
+import { OrderItemStatus } from "../OrderListPageType";
+
 export type LoginRequest = {
   username: string;
   password: string;
@@ -60,6 +62,12 @@ export type ItemAddExcelRequest = {
 };
 
 export type GetOrderListRequest = {
-  lastId: string | undefined;
+  lastOrderItemId: number | undefined;
   size: number;
+};
+
+export type PostChangeOrderItemRequest = {
+  orderItemId: number;
+  qty: number;
+  status: Omit<OrderItemStatus, "PENDING">;
 };

--- a/src/types/api/ApiRequestType.ts
+++ b/src/types/api/ApiRequestType.ts
@@ -58,3 +58,8 @@ export type ItemAddExcelRequest = {
   excelFile: File;
   onProgress?: (_percentage: number) => void;
 };
+
+export type GetOrderListRequest = {
+  lastId: string | undefined;
+  size: number;
+};

--- a/src/types/api/ApiResponseType.ts
+++ b/src/types/api/ApiResponseType.ts
@@ -1,6 +1,6 @@
 import { DayOfWeek } from "@/types/CongestionType";
 import { ItemType } from "../ItemType";
-import { OrderListItem } from "../OrderListPageType";
+import { OrderListItemType } from "../OrderListPageType";
 
 export type ApiResponse<T> = Promise<GlobalResponse<T>>;
 export type ApiResult<T> = Promise<T>;
@@ -135,6 +135,6 @@ export type VisitorStat = {
 };
 
 export type GetOrderListResponse = {
-  content: OrderListItem[];
+  content: OrderListItemType[];
   isLast: boolean;
 };

--- a/src/types/api/ApiResponseType.ts
+++ b/src/types/api/ApiResponseType.ts
@@ -1,5 +1,6 @@
 import { DayOfWeek } from "@/types/CongestionType";
 import { ItemType } from "../ItemType";
+import { OrderListItem } from "../OrderListPageType";
 
 export type ApiResponse<T> = Promise<GlobalResponse<T>>;
 export type ApiResult<T> = Promise<T>;
@@ -131,4 +132,9 @@ export type VisitorStat = {
   name: string;
   count: number;
   ratio: number;
+};
+
+export type GetOrderListResponse = {
+  content: OrderListItem[];
+  isLast: boolean;
 };

--- a/tests/LoginFlow.spec.ts
+++ b/tests/LoginFlow.spec.ts
@@ -14,18 +14,4 @@ test.describe("로그인 테스트", () => {
 
     await expect(page).toHaveURL("/popup-list");
   });
-
-  test("첫 번째 팝업을 선택하면 대시보드 이동한다.", async ({ page }) => {
-    await page.goto("/popup-list");
-
-    // const clickableElement = page
-    //   .locator('span[class*="cursor-pointer"]')
-    //   .first();
-
-    const clickableElement = page.locator('span[id^="popup-name-"]').first();
-
-    await expect(clickableElement).toBeVisible();
-    await clickableElement.click();
-    await expect(page).toHaveURL("/dashboard");
-  });
 });

--- a/tests/LoginFlow.spec.ts
+++ b/tests/LoginFlow.spec.ts
@@ -14,4 +14,18 @@ test.describe("로그인 테스트", () => {
 
     await expect(page).toHaveURL("/popup-list");
   });
+
+  test("첫 번째 팝업을 선택하면 대시보드 이동한다.", async ({ page }) => {
+    await page.goto("/popup-list");
+
+    // const clickableElement = page
+    //   .locator('span[class*="cursor-pointer"]')
+    //   .first();
+
+    const clickableElement = page.locator('span[id^="popup-name-"]').first();
+
+    await expect(clickableElement).toBeVisible();
+    await clickableElement.click();
+    await expect(page).toHaveURL("/dashboard");
+  });
 });


### PR DESCRIPTION
## 🌱 관련 이슈

- [LCR-302]

---

## 📌 작업 내용 및 특이사항

- 발주 내역 페이지 구현했습니다.
- 발주 내역 페이지에서는 발주 상품의 상태가 PENDING일 경우, 취소 혹은 승인 버튼을 클릭하여 발주 여부를 결정할 수 있습니다.
- 이미 취소 혹은 완료된 발주라면 발주 상품의 상태를 변경할 수 없습니다.
- 사용자는 실제 발주 수량을 지정하여 추천된 발주 수량과 비교하여 발주를 진행할 수 있습니다.

---

## 📚 참고사항
### 기본 UI
<img width="1520" alt="image" src="https://github.com/user-attachments/assets/348a41b7-02e7-47bd-a0e5-c0260c80b4e5" />

### 스크롤 맨 하단까지 이동한 경우
<img width="1520" alt="image" src="https://github.com/user-attachments/assets/728ce7a6-4bb8-4c9e-bc49-f92bf854d216" />

### 확인 모달
<img width="1526" alt="image" src="https://github.com/user-attachments/assets/9399d178-e168-4517-bfc6-35b949946414" />



[LCR-302]: https://lgcns-retail.atlassian.net/browse/LCR-302?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ