### PR TITLE
test: 헬퍼 함수 기능 테스트 구현

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -16,7 +16,8 @@ export default defineConfig({
   globalSetup: path.resolve("./tests/global-setup.ts"),
 
   use: {
-    baseURL: `${isCI ? process.env.VITE_DNS_URL : "http://localhost:3000"}`,
+    // baseURL: `${isCI ? process.env.VITE_DNS_URL : "http://localhost:3000"}`,
+    baseURL: "http://localhost:4173",
     trace: "on-first-retry",
     storageState: "tests/auth.json",
   },

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -16,8 +16,7 @@ export default defineConfig({
   globalSetup: path.resolve("./tests/global-setup.ts"),
 
   use: {
-    // baseURL: `${isCI ? process.env.VITE_DNS_URL : "http://localhost:3000"}`,
-    baseURL: "http://localhost:4173",
+    baseURL: `${isCI ? process.env.VITE_DNS_URL : "http://localhost:3000"}`,
     trace: "on-first-retry",
     storageState: "tests/auth.json",
   },

--- a/src/pages/popUpListPage/views/PopUpCard.tsx
+++ b/src/pages/popUpListPage/views/PopUpCard.tsx
@@ -63,7 +63,7 @@ export default function PopUpCard({
       <span
         onClick={handleSelect}
         lang="en"
-        id={`popup-name-${popupId}`}
+        data-testid={`popup-card-${popupId}`}
         className="cursor-pointer w-[286px] break-words block text-center justify-center text-[34px] mt-[22px]"
       >
         {isNameContainPopUp ? (

--- a/src/utils/TestHelper.ts
+++ b/src/utils/TestHelper.ts
@@ -13,7 +13,7 @@ export async function NavigateDashboard(page: Page) {
   await page.goto("/popup-list");
   await page.waitForLoadState("networkidle");
 
-  const allPopups = page.locator('span[id^="popup-name-"]');
+  const allPopups = page.locator('span[data-testid^="popup-card-"]');
   const firstPopup = allPopups.first();
 
   await firstPopup.waitFor({ state: "visible" });

--- a/tests/DefaultFlow.spec.ts
+++ b/tests/DefaultFlow.spec.ts
@@ -71,7 +71,7 @@ test.describe("헬퍼함수 기능 테스트 - 팝업 리스트 조회 및 대�
 
     // 조회된 데이터가 있을 경우와 없을 경우를 if문을 통해 분기 처리
     if (numOfPopupFromAPI !== 0) {
-      const allPopups = page.locator('span[id^="popup-name-"]');
+      const allPopups = page.locator('span[data-testid^="popup-card-"]');
       await expect(allPopups.first()).toBeVisible();
 
       const numOfPopupOnScreen = await allPopups.count();

--- a/tests/DefaultFlow.spec.ts
+++ b/tests/DefaultFlow.spec.ts
@@ -1,6 +1,6 @@
 import test, { expect } from "playwright/test";
 
-test.describe("헬퍼함수 기능 테스트", () => {
+test.describe("헬퍼함수 기능 테스트 - 로그인", () => {
   test.beforeEach(async ({ page }) => {
     await page.goto("/onboarding");
   });
@@ -46,5 +46,46 @@ test.describe("헬퍼함수 기능 테스트", () => {
     expect(responseBody.data).toHaveProperty("errorClassName");
 
     await expect(page.getByText("로그인에 실패했습니다")).toBeVisible();
+  });
+});
+
+test.describe("헬퍼함수 기능 테스트 - 팝업 리스트 조회 및 대쉬보드 이동", () => {
+  test("팝업 리스트 조회가 가능하고 팝업이 있다면, 클릭시 대시보드 페이지로 이동한다. \n 만약 팝업이 없다면, 등록된 팝업이 없다는 문구가 보인다.", async ({
+    page,
+  }) => {
+    // given & when - 팝업 리스트 이동시 조회 API 호출
+    const [responsePromise] = await Promise.all([
+      page.waitForResponse(response => {
+        const url = response.url();
+        return url.endsWith("/popups") && response.request().method() === "GET";
+      }),
+      page.goto("/popup-list"),
+    ]);
+
+    await page.waitForLoadState("networkidle"); // 네트워크가 안정화될 때까지 대기 -> waitFor과 동일한 효과 기대 가능
+
+    // then - 조회 결과 검증
+    expect(responsePromise.status()).toBe(200);
+    const responseBody = await responsePromise.json();
+    const numOfPopupFromAPI = responseBody.data.length;
+
+    // 조회된 데이터가 있을 경우와 없을 경우를 if문을 통해 분기 처리
+    if (numOfPopupFromAPI !== 0) {
+      const allPopups = page.locator('span[id^="popup-name-"]');
+      await expect(allPopups.first()).toBeVisible();
+
+      const numOfPopupOnScreen = await allPopups.count();
+
+      expect(numOfPopupFromAPI).toBeGreaterThan(0);
+      expect(numOfPopupFromAPI).toBe(numOfPopupOnScreen);
+
+      const firstPopup = allPopups.first();
+      await firstPopup.click({ timeout: 3000 });
+
+      await expect(page).toHaveURL("/dashboard");
+    } else {
+      await expect(page.getByText("등록된 팝업이 없습니다.")).toBeVisible();
+    }
+    await page.waitForLoadState("networkidle");
   });
 });


### PR DESCRIPTION
## 🌱 관련 이슈

- [LCR-302]

---

## 📌 작업 내용 및 특이사항

- 헬퍼함수 (로그인 & 팝업 리스트 이동) 테스트 코드 작성했습니다.
- Get 요청의 경우, 실제 개발 서버를 대상으로 테스트 코드를 작성하기 때문에 예외 상황 (리스트 조회가 되지 않는 상황)에 대한 테스트 케이스를 나눌 수 없습니다.
    - 예를들어서 팝업 리스트가 조회되는 경우와 조회되지 않는 경우의 테스트 케이스를 나눠서 코드를 작성했다고 가정해봅시다
    - 그렇게되면, 실제 DB에서 조회쿼리의 반환값이 넘어오기 때문에 무조건 하나는 성공하고 하나는 실패하게 됩니다.
    - 그렇다고 E2E 테스트에서 API를 모킹시켜서 테스트하는건 의미가 없다고 생각합니다.
    - 문서를 찾아보니 저희가 작성한 플로우처럼 진행하기 위해서는 Integration 테스트에 API를 모킹시켜서 테스트 코드를 작성해야할 것 같습니다. (할지 안할지는 아직 고민중)
- 따라서, 다음 코드와 같이 Get 요청에 대해서는 `하나의 테스트 케이스` 에서 분기처리로 나눠서 작업하도록 하겠습니다.
```typescript
// 조회된 데이터가 있을 경우와 없을 경우를 if문을 통해 분기 처리
if (numOfPopupFromAPI !== 0) {
  const allPopups = page.locator('span[id^="popup-name-"]');
  await expect(allPopups.first()).toBeVisible();

  const numOfPopupOnScreen = await allPopups.count();

  expect(numOfPopupFromAPI).toBeGreaterThan(0);
  expect(numOfPopupFromAPI).toBe(numOfPopupOnScreen);

  const firstPopup = allPopups.first();
  await firstPopup.click({ timeout: 3000 });

  await expect(page).toHaveURL("/dashboard");
} else {
  await expect(page.getByText("등록된 팝업이 없습니다.")).toBeVisible();
}
```
---

## 📚 참고사항
![image](https://github.com/user-attachments/assets/0a6bb49b-7a68-4524-bf3f-9e447969ffe9)



[LCR-302]: https://lgcns-retail.atlassian.net/browse/LCR-302?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ