### PR TITLE
refactor: 대시보드 페이지 리팩토링

### DIFF
--- a/src/components/common/NavBar.tsx
+++ b/src/components/common/NavBar.tsx
@@ -6,7 +6,10 @@ import { useEffect, useRef, useState } from "react";
 import NoticeModal from "@/components/noticeModal/NoticeModal";
 import { useAuth } from "@/hooks/useAuth";
 import { usePopUpReadStore } from "@/stores/usePopUpReadStore";
-import { connectNotificationSocket } from "@/utils/NotificationSocket";
+import {
+  connectNotificationSocket,
+  disconnectNotificationSocket,
+} from "@/utils/NotificationSocket";
 import { useNotificationStore } from "@/stores/useNotificationStore";
 
 export default function NavBar() {
@@ -20,12 +23,22 @@ export default function NavBar() {
 
   // WebSocket 연결 (NavBar가 처음 렌더링될 때)
   const connected = useRef(false);
+  const managerId = 1; // api 응답 변경되면 수정
+
   useEffect(() => {
     if (popupId && !connected.current) {
-      connectNotificationSocket("1", popupId);
+      connectNotificationSocket(managerId, popupId);
       connected.current = true;
     }
-  }, [popupId]);
+
+    // clean up
+    return () => {
+      if (connected.current) {
+        disconnectNotificationSocket();
+        connected.current = false;
+      }
+    };
+  }, [managerId, popupId]);
 
   return (
     <div
@@ -76,7 +89,7 @@ export default function NavBar() {
                   clearNewFlag(); // 모달 열면 빨간 점 지우기
                 }}
               >
-                <img src={alarmImage} width={24} height={24} />
+                <img src={alarmImage} alt="alarm" width={24} height={24} />
                 {hasNewNotification && (
                   <span className="absolute top-[2px] right-[2px] w-[8px] h-[8px] bg-main07 rounded-full" />
                 )}

--- a/src/components/noticeModal/NoticeModal.tsx
+++ b/src/components/noticeModal/NoticeModal.tsx
@@ -63,6 +63,7 @@ export default function NoticeModal({ onClose }: Props) {
               name={item.name ?? ""}
               minStock={item.minStock ?? 0}
               notifiedAt={item.notifiedAt ?? ""}
+              onClose={onClose}
             />
           ))
         ) : (

--- a/src/components/noticeModal/views/NoticeItem.tsx
+++ b/src/components/noticeModal/views/NoticeItem.tsx
@@ -1,8 +1,10 @@
 import { GetStockNotificationResponse } from "@/types/api/ApiResponseType";
 import { formatTimestamp } from "@/utils/FormatTimestamp";
+import { useNavigate } from "react-router-dom";
 
 type Props = Omit<GetStockNotificationResponse, "notificationId"> & {
   popUp: string;
+  onClose?: () => void;
 };
 
 export default function NoticeItem({
@@ -11,9 +13,20 @@ export default function NoticeItem({
   name,
   notifiedAt,
   minStock,
+  onClose,
 }: Props) {
+  const navigate = useNavigate();
+
+  const handleClick = () => {
+    onClose?.();
+    navigate("/order-list");
+  };
+
   return (
-    <div className="border-b border-b-gray03 w-full flex flex-col pt-3 pb-4">
+    <div
+      onClick={handleClick}
+      className="cursor-pointer border-b border-b-gray03 w-full flex flex-col pt-3 pb-4"
+    >
       <div className="flex justify-between items-center">
         <div className="flex items-center gap-[6px]">
           <span

--- a/src/index.css
+++ b/src/index.css
@@ -38,6 +38,7 @@ body {
   --color-gray08: #939494;
   --color-gray09: #59595a;
   --color-gray10: #1b1a1b;
+  --color-gray11: #7b7b7b;
 
   --color-purple01: #f5f5fe;
   --color-purple02: #ededfc;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -7,12 +7,12 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 export const queryClient = new QueryClient();
 
 async function startApp() {
-  if (import.meta.env.DEV) {
-    const { worker } = await import("./mocks/browser");
-    await worker.start({
-      onUnhandledRequest: "bypass",
-    });
-  }
+  // if (import.meta.env.DEV) {
+  //   const { worker } = await import("./mocks/browser");
+  //   await worker.start({
+  //     onUnhandledRequest: "bypass",
+  //   });
+  // }
 
   createRoot(document.getElementById("root")!).render(
     <StrictMode>

--- a/src/pages/dashboardPage/views/BestItem.tsx
+++ b/src/pages/dashboardPage/views/BestItem.tsx
@@ -129,7 +129,7 @@ const BestItemRoot = () => {
           ))}
         </div>
       ) : (
-        <div className="flex justify-center gap-[60px] mt-2 h-[300px]">
+        <div className="flex justify-center gap-[60px] mt-2 h-[512px] bg-gray02 rounded-[50px]">
           <NoDataCompt />
         </div>
       )}

--- a/src/pages/dashboardPage/views/BestItem.tsx
+++ b/src/pages/dashboardPage/views/BestItem.tsx
@@ -99,7 +99,7 @@ const BestItemCard = ({ item, index }: BestItemCardProps) => {
   );
 };
 
-export default function BestItem() {
+const BestItemRoot = () => {
   const { data, isLoading } = useBestItemsApi();
 
   return (
@@ -135,4 +135,10 @@ export default function BestItem() {
       )}
     </div>
   );
-}
+};
+
+BestItemRoot.Image = BestItemImage;
+BestItemRoot.Card = BestItemCard;
+
+const BestItem = BestItemRoot;
+export default BestItem;

--- a/src/pages/dashboardPage/views/BestItem.tsx
+++ b/src/pages/dashboardPage/views/BestItem.tsx
@@ -1,6 +1,24 @@
 import DashBoardTitle from "@/pages/dashboardPage/views/DashBoardTitle";
 import { useBestItemsApi } from "@/hooks/api/useDashboardApi";
 import NoDataCompt from "@/components/common/NoDataComp";
+import Skeleton from "@/components/common/Skeleton";
+import { useState } from "react";
+
+type BestItemImageProps = {
+  src: string;
+  alt: string;
+};
+
+type BestItemCardProps = {
+  item: {
+    itemId: number;
+    imagePath: string;
+    title: string;
+    price: number;
+    stock: number;
+  };
+  index: number;
+};
 
 const cardBgClass: Record<number, string> = {
   1: "bg-purple01",
@@ -14,62 +32,100 @@ const badgeBgClass: Record<number, string> = {
   3: "bg-mint07",
 };
 
-export default function BestItem() {
-  const { data } = useBestItemsApi();
+// 이미지 (Skeleton UI 포함)
+const BestItemImage = ({ src, alt }: BestItemImageProps) => {
+  const [isLoaded, setIsLoaded] = useState(false);
 
   return (
-    <div data-testid="dashboard-bestItems">
-      {/* 헤더 + 카테고리 */}
-      <div className="flex items-start gap-6">
-        <DashBoardTitle title="실시간 인기상품" />
-      </div>
+    <div className="w-[334px] h-[334px] mt-9 mb-3">
+      {!isLoaded && (
+        <div className="w-full h-full rounded-[20px] overflow-hidden">
+          <Skeleton />
+        </div>
+      )}
+      <img
+        src={src}
+        alt={alt}
+        className={`w-full h-full object-cover rounded-[20px] transition-opacity duration-300 ${
+          isLoaded ? "opacity-100" : "opacity-0"
+        }`}
+        onLoad={() => setIsLoaded(true)}
+      />
+    </div>
+  );
+};
 
-      {/* 베스트 상품 리스트 */}
-      {data && data.length > 0 ? (
-        <div className="flex justify-center gap-[60px] mt-2">
-          {data.map((item, index) => (
-            <div
-              key={item.itemId}
-              className={`
+// Card UI
+const BestItemCard = ({ item, index }: BestItemCardProps) => {
+  return (
+    <div
+      key={item.itemId}
+      className={`
                 relative flex flex-col items-center justify-center
-                w-[400px] rounded-[50px] px-[33px] pb-9
+                w-[400px] h-[512px] rounded-[50px] px-[33px] pb-9
                 ${cardBgClass[index + 1]}
               `}
-              data-testid={`dashboard-bestItems-${index}`}
-            >
-              {/* 순위 뱃지 */}
-              <div
-                className={`
+      data-testid={`dashboard-bestItems-${index}`}
+    >
+      {/* 순위 뱃지 */}
+      <div
+        className={`
                   absolute -top-[20px] -left-[20px]
                   w-[56px] h-[56px] rounded-full
                   text-white font-bold text-[30px]
                   flex items-center justify-center 
                   ${badgeBgClass[index + 1]}
                 `}
-              >
-                {index + 1}
-              </div>
+      >
+        {index + 1}
+      </div>
 
-              {/* 상품 이미지 */}
-              <div className="mb-6">
-                <img
-                  src={item.imagePath}
-                  alt={item.title}
-                  className="w-[334px] h-[334px] object-cover mt-9 mb-4"
-                />
-              </div>
+      {/* 상품 이미지 */}
+      <div className="mb-2">
+        <BestItemImage src={item.imagePath} alt={item.title} />
+      </div>
 
-              {/* 상품 정보 */}
-              <div className="text-center">
-                <div className="text-[24px] mb-2 text-gray10 font-semibold leading-[132%] tracking-[-0.48px] font-pretendard">
-                  {item.title}
-                </div>
-                <div className="text-[20px] text-gray08 font-medium leading-[132%] tracking-[-0.36px] mt-1 font-pretendard">
-                  {item.price.toLocaleString()}원<br />
-                  남은재고 : {item.stock}
-                </div>
-              </div>
+      {/* 상품 정보 */}
+      <div className="text-center">
+        <div className="truncate max-w-[320px] text-[24px] mb-[6px] text-gray10 font-semibold leading-[132%] tracking-[-0.48px] font-pretendard">
+          {item.title}
+        </div>
+        <div className="truncate max-w-[320px] text-[20px] text-gray11 font-medium leading-[132%] tracking-[-0.36px] font-pretendard">
+          {item.price.toLocaleString("ko-KR")} 원<br />
+          남은재고 : {item.stock}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default function BestItem() {
+  const { data, isLoading } = useBestItemsApi();
+
+  return (
+    <div data-testid="dashboard-bestItems">
+      {/* Title */}
+      <div className="flex items-start gap-6">
+        <DashBoardTitle title="실시간 인기상품" />
+      </div>
+
+      {/* 인기 상품 카드 */}
+      {isLoading ? (
+        // Skeleton UI
+        <div className="flex justify-center gap-[60px] mt-2">
+          {[1, 2, 3].map(i => (
+            <div
+              key={i}
+              className="w-[400px] h-[512px] rounded-[50px] overflow-hidden"
+            >
+              <Skeleton />
             </div>
+          ))}
+        </div>
+      ) : data && data.length > 0 ? (
+        <div className="flex justify-center gap-[60px] mt-2">
+          {data.map((item, index) => (
+            <BestItemCard key={item.itemId} item={item} index={index} />
           ))}
         </div>
       ) : (

--- a/src/pages/dashboardPage/views/DashBoardCustomerTransaction.tsx
+++ b/src/pages/dashboardPage/views/DashBoardCustomerTransaction.tsx
@@ -1,6 +1,7 @@
 import { useAvgPurchaseApi } from "@/hooks/api/useDashboardApi";
 import { CountCard } from "@/pages/dashboardPage/views/CountCard";
 import DashBoardTitle from "@/pages/dashboardPage/views/DashBoardTitle";
+import NoDataCompt from "@/components/common/NoDataComp";
 
 export default function DashBoardCustomerTransaction() {
   const { data } = useAvgPurchaseApi();
@@ -9,7 +10,7 @@ export default function DashBoardCustomerTransaction() {
     <div className="w-[414px] flex-col" data-testid="dashboard-transaction">
       <DashBoardTitle title="1인 평균 구매액" />
       <div className="flex h-[394px] flex-col justify-between">
-        {data && (
+        {data ? (
           <>
             <CountCard
               title="팝업 기간 내"
@@ -28,6 +29,10 @@ export default function DashBoardCustomerTransaction() {
               unitCSS="text-blue07 text-[40px]"
             />
           </>
+        ) : (
+          <div className="flex justify-center h-[394px] bg-gray02 rounded-[50px]">
+            <NoDataCompt />
+          </div>
         )}
       </div>
     </div>

--- a/src/pages/dashboardPage/views/DashBoardQuestionnaire.tsx
+++ b/src/pages/dashboardPage/views/DashBoardQuestionnaire.tsx
@@ -7,6 +7,7 @@ import { useQuestionnaireApi } from "@/hooks/api/useDashboardApi";
 import { QuestionnaireResponse } from "@/types/api/ApiResponseType";
 import { Questions } from "@/constants/popUpCreate/Questions";
 import Loading from "@/components/common/Loading";
+import NoDataComp from "@/components/common/NoDataComp";
 
 const options = ["1번 문항", "2번 문항", "3번 문항", "4번 문항"];
 const SIZE = 300;
@@ -88,7 +89,7 @@ export default function DashBoardQuestionnaire() {
         </div>
         <div className="w-[1360px] h-[662px] bg-gray02 rounded-[50px] px-[60px] py-[45px] flex items-center justify-center">
           <p className="text-[24px] text-gray08">
-            {isLoading ? <Loading /> : "설문 데이터가 없습니다."}
+            {isLoading ? <Loading /> : <NoDataComp />}
           </p>
         </div>
       </div>

--- a/src/pages/dashboardPage/views/DashBoardQuestionnaire.tsx
+++ b/src/pages/dashboardPage/views/DashBoardQuestionnaire.tsx
@@ -6,8 +6,8 @@ import CustomTooltip from "@/components/common/CustomTooltip";
 import { useQuestionnaireApi } from "@/hooks/api/useDashboardApi";
 import { QuestionnaireResponse } from "@/types/api/ApiResponseType";
 import { Questions } from "@/constants/popUpCreate/Questions";
-import Loading from "@/components/common/Loading";
 import NoDataComp from "@/components/common/NoDataComp";
+import Skeleton from "@/components/common/Skeleton";
 
 const options = ["1번 문항", "2번 문항", "3번 문항", "4번 문항"];
 const SIZE = 300;
@@ -70,32 +70,6 @@ export default function DashBoardQuestionnaire() {
 
   const matched = matchQA(selectedQuestion, surveys);
 
-  // 로딩 중이거나 데이터가 없을 때
-  if (isLoading || !matched) {
-    return (
-      <div
-        className="flex flex-col"
-        data-testid="dashboard-questionnaire-data-empty"
-      >
-        <div className="relative flex gap-[20px]">
-          <DashBoardTitle title="설문지 분석" />
-          <div className="ml-2">
-            <DropdownFilter
-              value={selectedQuestion}
-              options={options}
-              onChange={handleQuestion}
-            />
-          </div>
-        </div>
-        <div className="w-[1360px] h-[662px] bg-gray02 rounded-[50px] px-[60px] py-[45px] flex items-center justify-center">
-          <p className="text-[24px] text-gray08">
-            {isLoading ? <Loading /> : <NoDataComp />}
-          </p>
-        </div>
-      </div>
-    );
-  }
-
   return (
     <div
       className="flex flex-col"
@@ -111,122 +85,132 @@ export default function DashBoardQuestionnaire() {
           />
         </div>
       </div>
-      <div className="w-[1360px] h-[662px] bg-gray02 rounded-[50px] px-[60px] py-[45px]">
-        <p className="font-semibold text-[36px]">
-          {matchQuestion(selectedQuestion)}
-        </p>
-        <div className="flex">
-          <div className="w-[1240px] h-[490px] bg-gray01 mt-[40px] rounded-[40px] px-[40px] py-[30px] flex justify-between">
-            {/* 왼쪽 - 답변 리스트 */}
-            <div className="flex flex-col gap-[20px] w-[458px]">
-              {matched.contents.map((content, idx) => (
-                <div key={idx}>
-                  <div className="rounded-[20px] bg-gray02 text-[20px] flex items-center h-[72px] w-full">
-                    <span className="mr-4 w-[64px] h-full flex items-center justify-center rounded-l-[20px] text-[32px] bg-blue02">
-                      {idx + 1}
-                    </span>
-                    <p className="text-[20px] ml-[30px]">{content.title}</p>
+      {isLoading ? (
+        <div className="w-[1360px] h-[662px] rounded-[50px] overflow-hidden">
+          <Skeleton />
+        </div>
+      ) : !matched ? (
+        <div className="w-[1360px] h-[662px] bg-gray02 rounded-[50px]">
+          <NoDataComp />
+        </div>
+      ) : (
+        <div className="w-[1360px] h-[662px] bg-gray02 rounded-[50px] px-[60px] py-[45px]">
+          <p className="font-semibold text-[36px]">
+            {matchQuestion(selectedQuestion)}
+          </p>
+          <div className="flex">
+            <div className="w-[1240px] h-[490px] bg-gray01 mt-[40px] rounded-[40px] px-[40px] py-[30px] flex justify-between">
+              {/* 왼쪽 - 답변 리스트 */}
+              <div className="flex flex-col gap-[20px] w-[458px]">
+                {matched.contents.map((content, idx) => (
+                  <div key={idx}>
+                    <div className="rounded-[20px] bg-gray02 text-[20px] flex items-center h-[72px] w-full">
+                      <span className="mr-4 w-[64px] h-full flex items-center justify-center rounded-l-[20px] text-[32px] bg-blue02">
+                        {idx + 1}
+                      </span>
+                      <p className="text-[20px] ml-[30px]">{content.title}</p>
+                    </div>
                   </div>
-                </div>
-              ))}
-            </div>
-            {/* 오른쪽 - 파이 차트 */}
-            <div className="flex flex-col items-end h-full">
-              <p className="text-[20px] font-medium text-gray08">
-                전체 응시자 수: {matched.total}명
-              </p>
-              <div className="flex justify-center gap-[80px] items-center">
-                {isZeroTotal(matched) ? (
-                  // 모든 항목의 값이 0인 경우 메시지 표시
-                  <div className="flex items-center justify-center w-[300px] h-[300px]">
-                    <p className="text-[20px] text-gray08 text-center">
-                      아직 응답한 데이터가 없습니다.
-                    </p>
-                  </div>
-                ) : (
-                  // 정상적인 파이 차트 표시
-                  <PieChart width={SIZE} height={SIZE}>
-                    <Tooltip
-                      cursor={{ fill: "transparent" }}
-                      content={(props: TooltipProps<number, string>) => {
-                        if (
-                          !props.active ||
-                          !props.payload ||
-                          props.payload.length === 0
-                        )
-                          return null;
+                ))}
+              </div>
+              {/* 오른쪽 - 파이 차트 */}
+              <div className="flex flex-col items-end h-full">
+                <p className="text-[20px] font-medium text-gray08">
+                  전체 응시자 수: {matched.total}명
+                </p>
+                <div className="flex justify-center gap-[80px] items-center">
+                  {isZeroTotal(matched) ? (
+                    // 모든 항목의 값이 0인 경우 메시지 표시
+                    <div className="flex items-center justify-center w-[300px] h-[300px]">
+                      <p className="text-[20px] text-gray08 text-center">
+                        아직 응답한 데이터가 없습니다.
+                      </p>
+                    </div>
+                  ) : (
+                    // 정상적인 파이 차트 표시
+                    <PieChart width={SIZE} height={SIZE}>
+                      <Tooltip
+                        cursor={{ fill: "transparent" }}
+                        content={(props: TooltipProps<number, string>) => {
+                          if (
+                            !props.active ||
+                            !props.payload ||
+                            props.payload.length === 0
+                          )
+                            return null;
 
-                        const targetPayload = props.payload[0].payload;
-                        return (
-                          <CustomTooltip
-                            active={props.active}
-                            payload={[
-                              {
-                                value: targetPayload.selectedCount,
-                                name: targetPayload.title,
-                                dataKey: "selectedCount",
-                              },
-                            ]}
-                            label={targetPayload.title}
-                            unitSuffix="명"
-                            highlightColor={
-                              colorSet[
-                                props.payload[0].dataKey === "selectedCount"
-                                  ? matched.contents.findIndex(
-                                      c => c.title === targetPayload.title,
-                                    ) % colorSet.length
-                                  : 0
-                              ]
-                            }
-                          />
-                        );
-                      }}
-                    />
-
-                    <Pie
-                      data={matched.contents}
-                      innerRadius={0}
-                      outerRadius={RADIUS}
-                      dataKey="selectedCount"
-                      nameKey="title"
-                      cx="50%"
-                      cy="50%"
-                      paddingAngle={0}
-                    >
-                      {matched.contents.map((_, idx) => (
-                        <Cell
-                          key={idx}
-                          fill={colorSet[idx % colorSet.length]}
-                        />
-                      ))}
-                    </Pie>
-                  </PieChart>
-                )}
-                <div className="grid grid-cols-2 gap-x-6 gap-y-4 h-[100px]">
-                  {matched.contents.map((content, idx) => (
-                    <div key={idx} className="flex items-center gap-2">
-                      <span
-                        className="w-[38px] h-[18px] rounded-[8px]"
-                        style={{
-                          backgroundColor: colorSet[idx % colorSet.length],
+                          const targetPayload = props.payload[0].payload;
+                          return (
+                            <CustomTooltip
+                              active={props.active}
+                              payload={[
+                                {
+                                  value: targetPayload.selectedCount,
+                                  name: targetPayload.title,
+                                  dataKey: "selectedCount",
+                                },
+                              ]}
+                              label={targetPayload.title}
+                              unitSuffix="명"
+                              highlightColor={
+                                colorSet[
+                                  props.payload[0].dataKey === "selectedCount"
+                                    ? matched.contents.findIndex(
+                                        c => c.title === targetPayload.title,
+                                      ) % colorSet.length
+                                    : 0
+                                ]
+                              }
+                            />
+                          );
                         }}
                       />
-                      <span className="flex gap-2">
-                        <span>{idx + 1}번</span>
-                        {isZeroTotal(matched) && (
-                          <span className="text-gray06">
-                            ({content.selectedCount}명)
-                          </span>
-                        )}
-                      </span>
-                    </div>
-                  ))}
+
+                      <Pie
+                        data={matched.contents}
+                        innerRadius={0}
+                        outerRadius={RADIUS}
+                        dataKey="selectedCount"
+                        nameKey="title"
+                        cx="50%"
+                        cy="50%"
+                        paddingAngle={0}
+                      >
+                        {matched.contents.map((_, idx) => (
+                          <Cell
+                            key={idx}
+                            fill={colorSet[idx % colorSet.length]}
+                          />
+                        ))}
+                      </Pie>
+                    </PieChart>
+                  )}
+                  <div className="grid grid-cols-2 gap-x-6 gap-y-4 h-[100px]">
+                    {matched.contents.map((content, idx) => (
+                      <div key={idx} className="flex items-center gap-2">
+                        <span
+                          className="w-[38px] h-[18px] rounded-[8px]"
+                          style={{
+                            backgroundColor: colorSet[idx % colorSet.length],
+                          }}
+                        />
+                        <span className="flex gap-2">
+                          <span>{idx + 1}번</span>
+                          {isZeroTotal(matched) && (
+                            <span className="text-gray06">
+                              ({content.selectedCount}명)
+                            </span>
+                          )}
+                        </span>
+                      </div>
+                    ))}
+                  </div>
                 </div>
               </div>
             </div>
           </div>
         </div>
-      </div>
+      )}
     </div>
   );
 }

--- a/src/pages/dashboardPage/views/DashBoardReservation.tsx
+++ b/src/pages/dashboardPage/views/DashBoardReservation.tsx
@@ -15,7 +15,7 @@ export default function DashBoardReservation() {
   return (
     <div className="w-[906px] flex-col" data-testid="dashboard-reservation">
       <DashBoardTitle title="예약 분석" />
-      {entrantsData && reservationsData && (
+      {entrantsData && reservationsData ? (
         <div className="w-[1360px] h-[394px] flex gap-10">
           <div className="w-[314px] flex flex-col justify-between">
             <CountCard
@@ -57,6 +57,10 @@ export default function DashBoardReservation() {
               </div>
             )}
           </div>
+        </div>
+      ) : (
+        <div className="w-[906px] h-[394px] -translate-x-6 pt-[22px] pb-[30px] bg-gray02 rounded-[50px]">
+          <NoDataCompt />
         </div>
       )}
     </div>

--- a/src/utils/NotificationSocket.ts
+++ b/src/utils/NotificationSocket.ts
@@ -10,7 +10,7 @@ export const connectNotificationSocket = (
   managerId: number,
   popupId: number,
 ) => {
-  if (client?.connected) return;
+  if (client?.active || client?.connected) return;
 
   const baseURL = import.meta.env.VITE_API_URL;
   const token = useAuthStore.getState().accessToken;

--- a/src/utils/NotificationSocket.ts
+++ b/src/utils/NotificationSocket.ts
@@ -5,8 +5,9 @@ import { useAuthStore } from "@/stores/useAuthStore";
 
 let client: Client;
 
+// 소켓 연결
 export const connectNotificationSocket = (
-  managerId: string,
+  managerId: number,
   popupId: number,
 ) => {
   if (client?.connected) return;
@@ -37,4 +38,11 @@ export const connectNotificationSocket = (
     },
   });
   client.activate();
+};
+
+// 소켓 연결 해제
+export const disconnectNotificationSocket = () => {
+  if (client && client.connected) {
+    client.deactivate();
+  }
 };


### PR DESCRIPTION
## 🌱 관련 이슈

- [LCR-334]

---

## 📌 작업 내용 및 특이사항

### Navbar

- websocket clean up 함수 추가하였습니다.
- alarm icon alt 추가하였습니다.
- noticeItem 클릭 시 모달 닫히고 라우팅하였습니다.

### BestItem

- API 받아오는 isLoading 동안 `Skeleton UI` 보여줍니다.
- 카드 중 이미지 부분만 `onLoad` 속성으로 `Skeleton UI` 보여줍니다.
- 카드 컴포넌트 파일 내 분리하였습니다. (BestItemCard)
- 이미지 컴포넌트 파일 내 분리하였습니다. (BestItemImage)
- 접근성 개선 위해 gray11 추가하였습니다. (gray8~9 사이 컬러)
- namespace 패턴 사용하였습니다. (다른 파일에서 쓸 일은 없지만 연습용 + 컴포넌트를 바라보는 시각 개선)
- 이미지에 대하여..
    - lazy loading을 쓰기엔 화면의 첫 부분이라 바로 보여야 합니다.
    - preload를 쓰기엔 정적인 이미지가 아니라 매번 서버에서 받아와야 합니다.
    - 서버에서 경량화시켜 제공해주면 더 빨라질듯합니다.

### 구매전환율, 설문지, 예약 분석
- isLoading 동안 skeleton 추가하였습니다.

---

## 📚 참고사항


https://github.com/user-attachments/assets/354c3d51-6097-4ab2-8053-c0b2e71aaf56




[LCR-334]: https://lgcns-retail.atlassian.net/browse/LCR-334?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ