### PR TITLE
refactor: 대시보드 Congestion 리팩토링

### DIFF
--- a/src/components/common/QueryComponent.tsx
+++ b/src/components/common/QueryComponent.tsx
@@ -13,7 +13,7 @@ type Props<T> = {
   children: (_data: T) => React.ReactNode;
 };
 
-export const QueryComponent = <T,>({
+const QueryComponent = <T,>({
   data,
   isLoading,
   isError,
@@ -37,3 +37,5 @@ export const QueryComponent = <T,>({
   }
   return <>{children(data)}</>;
 };
+
+export default QueryComponent;

--- a/src/pages/dashboardPage/DashBoardPage.tsx
+++ b/src/pages/dashboardPage/DashBoardPage.tsx
@@ -1,17 +1,17 @@
-import DashBoardCongestion from "@/pages/dashboardPage/views/DashBoardCongestion";
 import DashBoardCustomerTransaction from "@/pages/dashboardPage/views/DashBoardCustomerTransaction";
 import DashBoardReservation from "@/pages/dashboardPage/views/DashBoardReservation";
 import DashBoardConversionRate from "@/pages/dashboardPage/views/DashBoardConversionRate";
 import DashBoardVisitor from "@/pages/dashboardPage/views/DashBoardVisitor";
 import DashBoardQuestionnaire from "@/pages/dashboardPage/views/DashBoardQuestionnaire";
 import BestItem from "@/pages/dashboardPage/views/bestItem";
+import Congestion from "@/pages/dashboardPage/views/congestion";
 
-export default function DashBoardPage() {
+const DashBoardPage = () => {
   return (
     <div className="w-[1360px] mx-auto flex flex-col gap-[70px] pt-[50px] pb-[86px]">
       <BestItem />
       <div className="flex w-[1360px] justify-between">
-        <DashBoardCongestion />
+        <Congestion />
         <DashBoardVisitor />
       </div>
       <div className="flex w-[1360px] justify-between">
@@ -22,4 +22,6 @@ export default function DashBoardPage() {
       <DashBoardConversionRate />
     </div>
   );
-}
+};
+
+export default DashBoardPage;

--- a/src/pages/dashboardPage/views/DashBoardConversionRate.tsx
+++ b/src/pages/dashboardPage/views/DashBoardConversionRate.tsx
@@ -3,7 +3,7 @@ import { useConversionApi } from "@/hooks/api/useDashboardApi";
 import { ConversionRateChart } from "@/pages/dashboardPage/views/ConversionRateChart";
 import DashBoardTitle from "@/pages/dashboardPage/views/DashBoardTitle";
 import Skeleton from "@/components/common/Skeleton";
-import { QueryComponent } from "@/components/common/QueryComponent";
+import QueryComponent from "@/components/common/QueryComponent";
 
 export default function DashBoardConversionRate() {
   const { data, isLoading, isError } = useConversionApi();

--- a/src/pages/dashboardPage/views/DashBoardCustomerTransaction.tsx
+++ b/src/pages/dashboardPage/views/DashBoardCustomerTransaction.tsx
@@ -3,7 +3,7 @@ import { CountCard } from "@/pages/dashboardPage/views/CountCard";
 import DashBoardTitle from "@/pages/dashboardPage/views/DashBoardTitle";
 import NoDataComp from "@/components/common/NoDataComp";
 import Skeleton from "@/components/common/Skeleton";
-import { QueryComponent } from "@/components/common/QueryComponent";
+import QueryComponent from "@/components/common/QueryComponent";
 
 export default function DashBoardCustomerTransaction() {
   const { data, isLoading, isError } = useAvgPurchaseApi();

--- a/src/pages/dashboardPage/views/DashBoardQuestionnaire.tsx
+++ b/src/pages/dashboardPage/views/DashBoardQuestionnaire.tsx
@@ -8,7 +8,7 @@ import { QuestionnaireResponse } from "@/types/api/ApiResponseType";
 import { Questions } from "@/constants/popUpCreate/Questions";
 import NoDataComp from "@/components/common/NoDataComp";
 import Skeleton from "@/components/common/Skeleton";
-import { QueryComponent } from "@/components/common/QueryComponent";
+import QueryComponent from "@/components/common/QueryComponent";
 
 const options = ["1번 문항", "2번 문항", "3번 문항", "4번 문항"];
 const SIZE = 300;

--- a/src/pages/dashboardPage/views/DashBoardReservation.tsx
+++ b/src/pages/dashboardPage/views/DashBoardReservation.tsx
@@ -8,7 +8,7 @@ import {
 } from "@/hooks/api/useDashboardApi";
 import Skeleton from "@/components/common/Skeleton";
 import NoDataComp from "@/components/common/NoDataComp";
-import { QueryComponent } from "@/components/common/QueryComponent";
+import QueryComponent from "@/components/common/QueryComponent";
 
 export default function DashBoardReservation() {
   const entrants = useTodayEntrantsApi();

--- a/src/pages/dashboardPage/views/DashBoardVisitor.tsx
+++ b/src/pages/dashboardPage/views/DashBoardVisitor.tsx
@@ -3,7 +3,7 @@ import { mapGenderData, mapAgeData } from "@/utils/VisitorColorMapper";
 import VisitorPieChart from "@/pages/dashboardPage/views/VisitorPieChart";
 import { useVisitorStatsApi } from "@/hooks/api/useDashboardApi";
 import NoDataComp from "@/components/common/NoDataComp";
-import { QueryComponent } from "@/components/common/QueryComponent";
+import QueryComponent from "@/components/common/QueryComponent";
 import Skeleton from "@/components/common/Skeleton";
 
 export default function DashBoardVisitor() {

--- a/src/pages/dashboardPage/views/bestItem/BestItemCard.tsx
+++ b/src/pages/dashboardPage/views/bestItem/BestItemCard.tsx
@@ -1,5 +1,5 @@
-import { BestItemCardImage } from "@/pages/dashboardPage/views/bestItem/BestItemCardImage";
-import { memo } from "react";
+import React from "react";
+import BestItemCardImage from "@/pages/dashboardPage/views/bestItem/BestItemCardImage";
 
 type BestItemCardProps = {
   item: {
@@ -25,10 +25,7 @@ const badgeBgClass: Record<number, string> = {
 };
 
 // Card UI
-export const BestItemCard = memo(function BestItemCard({
-  item,
-  index,
-}: BestItemCardProps) {
+const BestItemCard = ({ item, index }: BestItemCardProps) => {
   return (
     <div
       key={item.itemId}
@@ -59,4 +56,6 @@ export const BestItemCard = memo(function BestItemCard({
       </div>
     </div>
   );
-});
+};
+
+export default React.memo(BestItemCard);

--- a/src/pages/dashboardPage/views/bestItem/BestItemCardImage.tsx
+++ b/src/pages/dashboardPage/views/bestItem/BestItemCardImage.tsx
@@ -1,5 +1,5 @@
-import Skeleton from "@/components/common/Skeleton";
 import { useState } from "react";
+import Skeleton from "@/components/common/Skeleton";
 
 type BestItemCardImageProps = {
   src: string;
@@ -7,7 +7,7 @@ type BestItemCardImageProps = {
 };
 
 // 이미지 (Skeleton UI 포함)
-export const BestItemCardImage = ({ src, alt }: BestItemCardImageProps) => {
+const BestItemCardImage = ({ src, alt }: BestItemCardImageProps) => {
   const [isLoaded, setIsLoaded] = useState(false);
 
   return (
@@ -28,3 +28,5 @@ export const BestItemCardImage = ({ src, alt }: BestItemCardImageProps) => {
     </div>
   );
 };
+
+export default BestItemCardImage;

--- a/src/pages/dashboardPage/views/bestItem/index.tsx
+++ b/src/pages/dashboardPage/views/bestItem/index.tsx
@@ -1,9 +1,9 @@
-import DashBoardTitle from "@/pages/dashboardPage/views/DashBoardTitle";
 import { useBestItemsApi } from "@/hooks/api/useDashboardApi";
 import Skeleton from "@/components/common/Skeleton";
-import { QueryComponent } from "@/components/common/QueryComponent";
+import QueryComponent from "@/components/common/QueryComponent";
 import NoDataComp from "@/components/common/NoDataComp";
-import { BestItemCard } from "@/pages/dashboardPage/views/bestItem/BestItemCard";
+import BestItemCard from "@/pages/dashboardPage/views/bestItem/BestItemCard";
+import DashBoardTitle from "@/pages/dashboardPage/views/DashBoardTitle";
 
 const BestItem = () => {
   const { data: bestItemData, isLoading, isError } = useBestItemsApi();

--- a/src/pages/dashboardPage/views/congestion/CongestionChart.tsx
+++ b/src/pages/dashboardPage/views/congestion/CongestionChart.tsx
@@ -3,7 +3,6 @@ import CustomCursor from "@/components/common/CustomCursor";
 import CustomTooltip from "@/components/common/CustomTooltip";
 import { congestionList } from "@/mocks/handlers/dashboard/CongestionRead.handlers";
 import { GetCongestionTimeValue } from "@/types/api/ApiResponseType";
-
 import {
   AreaChart,
   Area,
@@ -17,7 +16,7 @@ type Props = {
   dayData: GetCongestionTimeValue[];
 };
 
-export default function CongestionChart({ dayData }: Props) {
+const CongestionChart = ({ dayData }: Props) => {
   // y축 최댓값: 모든 요일 데이터 중 가장 큰 value
   const allValues = Object.values(congestionList)
     .flat()
@@ -67,4 +66,6 @@ export default function CongestionChart({ dayData }: Props) {
       </AreaChart>
     </ResponsiveContainer>
   );
-}
+};
+
+export default CongestionChart;

--- a/src/pages/dashboardPage/views/congestion/CongestionChart.tsx
+++ b/src/pages/dashboardPage/views/congestion/CongestionChart.tsx
@@ -10,7 +10,6 @@ import {
 import CustomBlurDot from "@/components/common/CustomBlurDot";
 import CustomCursor from "@/components/common/CustomCursor";
 import CustomTooltip from "@/components/common/CustomTooltip";
-import React from "react";
 
 type Props = {
   dayData: GetCongestionTimeValue[];
@@ -64,4 +63,4 @@ const CongestionChart = ({ dayData }: Props) => {
   );
 };
 
-export default React.memo(CongestionChart);
+export default CongestionChart;

--- a/src/pages/dashboardPage/views/congestion/CongestionChart.tsx
+++ b/src/pages/dashboardPage/views/congestion/CongestionChart.tsx
@@ -1,7 +1,3 @@
-import CustomBlurDot from "@/components/common/CustomBlurDot";
-import CustomCursor from "@/components/common/CustomCursor";
-import CustomTooltip from "@/components/common/CustomTooltip";
-import { congestionList } from "@/mocks/handlers/dashboard/CongestionRead.handlers";
 import { GetCongestionTimeValue } from "@/types/api/ApiResponseType";
 import {
   AreaChart,
@@ -11,6 +7,9 @@ import {
   Tooltip,
   YAxis,
 } from "recharts";
+import CustomBlurDot from "@/components/common/CustomBlurDot";
+import CustomCursor from "@/components/common/CustomCursor";
+import CustomTooltip from "@/components/common/CustomTooltip";
 
 type Props = {
   dayData: GetCongestionTimeValue[];
@@ -18,11 +17,7 @@ type Props = {
 
 const CongestionChart = ({ dayData }: Props) => {
   // y축 최댓값: 모든 요일 데이터 중 가장 큰 value
-  const allValues = Object.values(congestionList)
-    .flat()
-    .map(d => d.value);
-
-  const maxValue = Math.max(...allValues);
+  const maxValue = Math.max(...dayData.map(d => d.value));
 
   return (
     <ResponsiveContainer width="100%" height="100%">

--- a/src/pages/dashboardPage/views/congestion/CongestionChart.tsx
+++ b/src/pages/dashboardPage/views/congestion/CongestionChart.tsx
@@ -10,6 +10,7 @@ import {
 import CustomBlurDot from "@/components/common/CustomBlurDot";
 import CustomCursor from "@/components/common/CustomCursor";
 import CustomTooltip from "@/components/common/CustomTooltip";
+import React from "react";
 
 type Props = {
   dayData: GetCongestionTimeValue[];
@@ -63,4 +64,4 @@ const CongestionChart = ({ dayData }: Props) => {
   );
 };
 
-export default CongestionChart;
+export default React.memo(CongestionChart);

--- a/src/pages/dashboardPage/views/congestion/CongestionDaySelector.tsx
+++ b/src/pages/dashboardPage/views/congestion/CongestionDaySelector.tsx
@@ -1,7 +1,7 @@
+import React from "react";
 import { Days } from "@/constants/dashboard/Days";
 import { FormatDay } from "@/utils/FormatDay";
 import { DayOfWeek } from "@/types/CongestionType";
-import React from "react";
 
 type Props = {
   selectedDay: DayOfWeek;

--- a/src/pages/dashboardPage/views/congestion/CongestionDaySelector.tsx
+++ b/src/pages/dashboardPage/views/congestion/CongestionDaySelector.tsx
@@ -1,0 +1,28 @@
+import { Days } from "@/constants/dashboard/Days";
+import { FormatDay } from "@/utils/FormatDay";
+import { DayOfWeek } from "@/types/CongestionType";
+
+type Props = {
+  selectedDay: DayOfWeek;
+  onChange: (_day: DayOfWeek) => void;
+};
+
+const CongestionDaySelector = ({ selectedDay, onChange }: Props) => {
+  return (
+    <div className="mt-5 flex justify-center gap-6 mb-4">
+      {Days.map(day => (
+        <button
+          key={day}
+          onClick={() => onChange(day)}
+          className={`cursor-pointer w-[54px] h-[54px] text-gray09 rounded-full flex items-center justify-center font-medium text-[24px]
+            ${selectedDay === day && "bg-white border-mint07 border-2 rounded-full"}
+          `}
+        >
+          {FormatDay(day)}
+        </button>
+      ))}
+    </div>
+  );
+};
+
+export default CongestionDaySelector;

--- a/src/pages/dashboardPage/views/congestion/CongestionDaySelector.tsx
+++ b/src/pages/dashboardPage/views/congestion/CongestionDaySelector.tsx
@@ -1,6 +1,7 @@
 import { Days } from "@/constants/dashboard/Days";
 import { FormatDay } from "@/utils/FormatDay";
 import { DayOfWeek } from "@/types/CongestionType";
+import React from "react";
 
 type Props = {
   selectedDay: DayOfWeek;
@@ -25,4 +26,4 @@ const CongestionDaySelector = ({ selectedDay, onChange }: Props) => {
   );
 };
 
-export default CongestionDaySelector;
+export default React.memo(CongestionDaySelector);

--- a/src/pages/dashboardPage/views/congestion/index.tsx
+++ b/src/pages/dashboardPage/views/congestion/index.tsx
@@ -1,18 +1,19 @@
 import { useEffect, useState } from "react";
 import { Days } from "@/constants/dashboard/Days";
-import { FormatDay } from "@/utils/FormatDay";
-import DashBoardTitle from "@/pages/dashboardPage/views/DashBoardTitle";
-import CongestionChart from "@/pages/dashboardPage/views/CongestionChart";
 import { useCongestionApi } from "@/hooks/api/useDashboardApi";
 import { DayOfWeek } from "@/types/CongestionType";
+import DashBoardTitle from "@/pages/dashboardPage/views/DashBoardTitle";
 import NoDataComp from "@/components/common/NoDataComp";
-import { QueryComponent } from "@/components/common/QueryComponent";
+import QueryComponent from "@/components/common/QueryComponent";
 import Skeleton from "@/components/common/Skeleton";
+import CongestionChart from "@/pages/dashboardPage/views/congestion/CongestionChart";
+import CongestionDaySelector from "@/pages/dashboardPage/views/congestion/CongestionDaySelector";
 
-export default function DashBoardCongestion() {
+const Congestion = () => {
   const [selectedDay, setSelectedDay] = useState<DayOfWeek>(Days[0]);
   const { data, isLoading, isError } = useCongestionApi();
 
+  // 오늘 요일에 맞는 버튼 자동 선택
   useEffect(() => {
     if (data && !selectedDay) {
       const today = new Date().getDay();
@@ -25,20 +26,10 @@ export default function DashBoardCongestion() {
       <DashBoardTitle title="혼잡도 분석" />
       <div className="relative w-[660px] h-[510px] bg-gray02 rounded-[50px] px-6">
         {/* 요일 버튼 */}
-        <div className="mt-5 flex justify-center gap-6 mb-4">
-          {Days.map(day => (
-            <button
-              key={day}
-              onClick={() => setSelectedDay(day)}
-              className={`cursor-pointer w-[54px] h-[54px] text-gray09 rounded-full flex items-center justify-center font-medium text-[24px]
-                ${selectedDay === day && "bg-white border-mint07 border-2 rounded-full"}
-              `}
-            >
-              {FormatDay(day)}
-            </button>
-          ))}
-        </div>
-
+        <CongestionDaySelector
+          selectedDay={selectedDay}
+          onChange={setSelectedDay}
+        />
         {/* 그래프 영역 */}
         <QueryComponent
           data={data?.[selectedDay]}
@@ -55,13 +46,16 @@ export default function DashBoardCongestion() {
             </div>
           }
         >
-          {dayData => (
+          {data => (
             <div className="absolute bottom-6 w-[612px] h-[394px] bg-gray01 rounded-[40px] flex justify-center">
-              <CongestionChart dayData={dayData} />
+              {/* 혼잡도 분석 그래프 */}
+              <CongestionChart dayData={data} />
             </div>
           )}
         </QueryComponent>
       </div>
     </div>
   );
-}
+};
+
+export default Congestion;

--- a/src/pages/dashboardPage/views/congestion/index.tsx
+++ b/src/pages/dashboardPage/views/congestion/index.tsx
@@ -15,11 +15,11 @@ const Congestion = () => {
 
   // 오늘 요일에 맞는 버튼 자동 선택
   useEffect(() => {
-    if (data && !selectedDay) {
+    if (data) {
       const today = new Date().getDay();
       setSelectedDay(Days[today === 0 ? 6 : today - 1]);
     }
-  }, [data, selectedDay]);
+  }, [data]);
 
   return (
     <div className="flex flex-col" data-testid="dashboard-congestion">

--- a/src/utils/NotificationSocket.ts
+++ b/src/utils/NotificationSocket.ts
@@ -17,7 +17,7 @@ export const connectNotificationSocket = (
 
   client = new Client({
     webSocketFactory: () => new SockJS(`${baseURL}/ws`),
-    reconnectDelay: 5000,
+    reconnectDelay: 60000,
     connectHeaders: {
       Authorization: `Bearer ${token}`,
     },


### PR DESCRIPTION
## 🌱 관련 이슈

- [LCR-345]

---

## 📌 작업 내용 및 특이사항

- 컴포넌트 분리하였습니다.
<img width="610" alt="image" src="https://github.com/user-attachments/assets/c12c45c2-94f8-4ae1-8734-bcb54423b3be" />
<img width="674" alt="image" src="https://github.com/user-attachments/assets/074861e4-6e63-42a9-a79a-4f55e2caebae" />

- CongestionDaySelector와 CongestionChart에 React.memo 적용하였습니다.
- 기존 mock data 기준으로 y축 최댓값을 설정했던 코드를 실제 data 기준으로 수정하였습니다.

---

## 📚 참고사항
<img width="719" alt="image" src="https://github.com/user-attachments/assets/65debfad-fd25-46d3-98bf-0c3305cebf8c" />



[LCR-345]: https://lgcns-retail.atlassian.net/browse/LCR-345?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ