### PR TITLE
refactor: components 내부 구조 개선 및 분리

### DIFF
--- a/src/components/common/ConditionalComponent.tsx
+++ b/src/components/common/ConditionalComponent.tsx
@@ -1,3 +1,16 @@
+/**
+ * @Description
+ * 조건부 렌더링을 위한 컴포넌트입니다.
+ * - `when` 값이 falsy하거나 빈 배열이면 `fallback`을 렌더링합니다.
+ * - `children`이 함수일 경우, `when` 값을 인자로 호출해 렌더링합니다.
+ * - 그 외에는 `children` 자체를 그대로 렌더링합니다.
+ *
+ * @Example
+ * <ConditionalComponent when={data} fallback={<div>데이터 없음</div>}>
+ *   {(validData) => <div>{validData.name}</div>}
+ * </ConditionalComponent>
+ */
+
 import React from "react";
 
 function ConditionalComponent<T>({

--- a/src/components/common/Modal.tsx
+++ b/src/components/common/Modal.tsx
@@ -1,8 +1,8 @@
 /**
  * @Description
  * 모달 공통 컴포넌트입니다
- * onCancel이 없으면 버튼이 한 개만 있는 alert 모달이고,
- * onCancel까지 있으면 버튼이 두 개 있는 confirm 모달이 됩니다.
+ * - `onCancel`이 없으면 버튼이 한 개만 있는 `alert 모달`이 됩니다.
+ * - `onCancel`이 있으면 버튼이 두 개 있는 `confirm 모달`이 됩니다.
  */
 
 import { useEffect } from "react";
@@ -20,7 +20,7 @@ type Props = {
   onCancel?: () => void;
 };
 
-export default function Modal({
+const Modal = ({
   isOpen,
   setIsOpen,
   content,
@@ -29,7 +29,7 @@ export default function Modal({
   cancelText,
   onConfirm,
   onCancel,
-}: Props) {
+}: Props) => {
   const handleClose = () => {
     if (onCancel) {
       onCancel(); // Confirm 모달일 경우 취소만
@@ -119,4 +119,6 @@ export default function Modal({
       </div>
     </div>
   );
-}
+};
+
+export default Modal;

--- a/src/components/common/NavBar.tsx
+++ b/src/components/common/NavBar.tsx
@@ -1,3 +1,11 @@
+/**
+ * @Description
+ * 네비게이션 바 컴포넌트입니다.
+ * - 로그인 여부에 따라 로그아웃 버튼을 표시하며, 로그인 상태에서만 사용 가능합니다.
+ * - `popupId`가 설정된 경우, 알림용 WebSocket을 연결하여 실시간 알림 수신을 지원합니다.
+ * - 알림 아이콘 클릭 시 알림 모달(noticeModal)을 띄우며, 새로운 알림이 있는 경우 빨간 점으로 표시합니다.
+ */
+
 import { NavLink, useLocation, useNavigate } from "react-router-dom";
 import { NavigationItems } from "@/constants/NavigationItems";
 import logoImage from "@/assets/webps/common/logo-manager.webp";
@@ -12,7 +20,7 @@ import {
 } from "@/utils/NotificationSocket";
 import { useNotificationStore } from "@/stores/useNotificationStore";
 
-export default function NavBar() {
+const NavBar = () => {
   const { isLogin, logout } = useAuth();
   const navigate = useNavigate();
   const [isNoticeModalOpen, setIsNoticeModalOpen] = useState(false);
@@ -114,4 +122,6 @@ export default function NavBar() {
       </div>
     </div>
   );
-}
+};
+
+export default NavBar;

--- a/src/components/common/NavBar.tsx
+++ b/src/components/common/NavBar.tsx
@@ -14,10 +14,7 @@ import { useEffect, useRef, useState } from "react";
 import NoticeModal from "@/components/noticeModal/NoticeModal";
 import { useAuth } from "@/hooks/useAuth";
 import { usePopUpReadStore } from "@/stores/usePopUpReadStore";
-import {
-  connectNotificationSocket,
-  disconnectNotificationSocket,
-} from "@/utils/NotificationSocket";
+import { connectNotificationSocket } from "@/utils/NotificationSocket";
 import { useNotificationStore } from "@/stores/useNotificationStore";
 
 const NavBar = () => {
@@ -38,14 +35,6 @@ const NavBar = () => {
       connectNotificationSocket(managerId, popupId);
       connected.current = true;
     }
-
-    // clean up
-    return () => {
-      if (connected.current) {
-        disconnectNotificationSocket();
-        connected.current = false;
-      }
-    };
   }, [managerId, popupId]);
 
   return (

--- a/src/components/common/QueryComponent.tsx
+++ b/src/components/common/QueryComponent.tsx
@@ -1,6 +1,22 @@
+/**
+ * @description
+ * React Query 요청의 로딩, 에러, 빈 데이터 상태를 공통 처리하는 래퍼 컴포넌트입니다.
+ * - `data`, `isLoading`, `isError` 상태에 따라 적절한 fallback UI를 렌더링하고,
+ * - 데이터가 존재할 경우 `children` 함수로 실제 UI를 렌더링합니다.
+ *
+ * @example
+ * <QueryComponent
+ *   data={data}
+ *   isLoading={isLoading}
+ *   isError={isError}
+ * >
+ *   {(data) => <MyList data={data} />}
+ * </QueryComponent>
+ */
+
 import React from "react";
-import Skeleton from "./Skeleton";
-import NoDataComp from "./NoDataComp";
+import Skeleton from "../ui/Skeleton";
+import NoDataComp from "../../pages/dashboardPage/views/@common/NoDataComp";
 
 type Props<T> = {
   data: T | undefined;

--- a/src/components/ui/CustomButton.stories.tsx
+++ b/src/components/ui/CustomButton.stories.tsx
@@ -1,4 +1,4 @@
-import CustomButton from "@/components/common/CustomButton";
+import CustomButton from "@/components/ui/CustomButton";
 import { Meta, StoryObj } from "@storybook/react";
 
 const meta: Meta<typeof CustomButton> = {

--- a/src/components/ui/CustomButton.tsx
+++ b/src/components/ui/CustomButton.tsx
@@ -1,10 +1,15 @@
+/**
+ * @Description
+ * 커스텀 스타일을 적용할 수 있는 버튼 공통 컴포넌트입니다.
+ */
+
 type Props = {
   label: string;
   cssOption: string;
   onClick: () => void;
 };
 
-export default function CustomButton({ label, cssOption, onClick }: Props) {
+const CustomButton = ({ label, cssOption, onClick }: Props) => {
   return (
     <button
       className={`rounded-full px-[20px] py-[10px] text-center cursor-pointer ${cssOption}`}
@@ -13,4 +18,6 @@ export default function CustomButton({ label, cssOption, onClick }: Props) {
       {label}
     </button>
   );
-}
+};
+
+export default CustomButton;

--- a/src/components/ui/CustomInput.stories.tsx
+++ b/src/components/ui/CustomInput.stories.tsx
@@ -1,4 +1,4 @@
-import CustomInput from "@/components/common/CustomInput";
+import CustomInput from "@/components/ui/CustomInput";
 import { Meta, StoryObj } from "@storybook/react";
 
 const meta: Meta<typeof CustomInput> = {

--- a/src/components/ui/CustomInput.tsx
+++ b/src/components/ui/CustomInput.tsx
@@ -1,3 +1,8 @@
+/**
+ * @Description
+ * 커스텀 스타일을 적용할 수 있는 입력 필드 공통 컴포넌트입니다.
+ */
+
 import React from "react";
 
 type Props = {
@@ -15,7 +20,7 @@ type Props = {
   maxValue?: number;
 };
 
-export default function CustomInput({
+const CustomInput = ({
   inputType,
   isOnlyNumber = false,
   title,
@@ -28,7 +33,7 @@ export default function CustomInput({
   isPatchMode = false,
   onKeyDown,
   maxValue,
-}: Props) {
+}: Props) => {
   const numberHandler = (e: React.FormEvent<HTMLInputElement>) => {
     if (isOnlyNumber) {
       const input = e.currentTarget;
@@ -80,4 +85,6 @@ export default function CustomInput({
       )}
     </div>
   );
-}
+};
+
+export default CustomInput;

--- a/src/components/ui/Loading.tsx
+++ b/src/components/ui/Loading.tsx
@@ -1,6 +1,11 @@
+/**
+ * @Description
+ * 로딩 애니메이션을 보여주는 로딩 컴포넌트입니다.
+ */
+
 import { motion } from "framer-motion";
 
-export default function Loading() {
+const Loading = () => {
   return (
     <div className="flex items-center justify-center p-4">
       <div className="flex space-x-3">
@@ -69,4 +74,6 @@ export default function Loading() {
       </div>
     </div>
   );
-}
+};
+
+export default Loading;

--- a/src/components/ui/NoImageComp.tsx
+++ b/src/components/ui/NoImageComp.tsx
@@ -1,8 +1,14 @@
+/**
+ * @Description
+ * 이미지가 업로드되지 않은 상태를 시각적으로 안내하는 컴포넌트입니다.
+ */
+
 type Props = {
   width: number;
   height: number;
 };
-export default function NoImageComp({ width, height }: Props) {
+
+const NoImageComp = ({ width, height }: Props) => {
   return (
     <div
       className="flex flex-col items-center justify-center text-center p-6 border-dashed border-2 border-gray05 rounded-lg"
@@ -16,4 +22,6 @@ export default function NoImageComp({ width, height }: Props) {
       </p>
     </div>
   );
-}
+};
+
+export default NoImageComp;

--- a/src/components/ui/Skeleton.tsx
+++ b/src/components/ui/Skeleton.tsx
@@ -1,6 +1,19 @@
+/**
+ * @Description
+ * 로딩 중임을 나타내는 스켈레톤 컴포넌트입니다.
+ * - `framer-motion`을 활용하여 좌우로 흐르는 반짝이는 효과를 제공합니다.
+ * - 부모 요소의 `width`, `height`를 상속받아 전체 영역에 적용됩니다.
+ * - API 응답 대기 중, 콘텐츠의 자리를 미리 확보하거나 시각적 피드백을 줄 때 사용합니다.
+ *
+ * @Example
+ * <div className="w-[300px] h-[100px]">
+ *   <Skeleton />
+ * </div>
+ */
+
 import { motion } from "framer-motion";
 
-export default function Skeleton() {
+const Skeleton = () => {
   return (
     <motion.div
       className="relative overflow-hidden bg-gray-200 w-full h-full"
@@ -21,4 +34,6 @@ export default function Skeleton() {
       />
     </motion.div>
   );
-}
+};
+
+export default Skeleton;

--- a/src/pages/dashboardPage/views/@common/CountCard.tsx
+++ b/src/pages/dashboardPage/views/@common/CountCard.tsx
@@ -1,3 +1,8 @@
+/**
+ * @Description
+ * 예약자 수, 입장자 수, 1인 평균 구매액에서 사용되는 count card UI입니다.
+ */
+
 type Props = {
   bgCSS: string;
   title: string;
@@ -7,15 +12,7 @@ type Props = {
   unit: string;
 };
 
-// 예약자 수, 입장자 수, 1인 평균 구매액 count card
-export function CountCard({
-  bgCSS,
-  title,
-  valueCSS,
-  value,
-  unitCSS,
-  unit,
-}: Props) {
+const CountCard = ({ bgCSS, title, valueCSS, value, unitCSS, unit }: Props) => {
   return (
     <div
       className={`${bgCSS} rounded-[40px] h-[180px] flex flex-col justify-center items-center`}
@@ -31,4 +28,6 @@ export function CountCard({
       </p>
     </div>
   );
-}
+};
+
+export default CountCard;

--- a/src/pages/dashboardPage/views/@common/CustomBlurDot.tsx
+++ b/src/pages/dashboardPage/views/@common/CustomBlurDot.tsx
@@ -1,10 +1,15 @@
+/**
+ * @Description
+ * rechart 라이브러리를 활용한 그래프에서 사용되는 Dot UI입니다.
+ */
+
 import { DotProps } from "recharts";
 
 type Props = DotProps & {
   fillColor: string;
 };
 
-export default function CustomBlurDot({ cx, cy, fillColor }: Props) {
+const CustomBlurDot = ({ cx, cy, fillColor }: Props) => {
   return (
     <circle
       cx={cx}
@@ -16,4 +21,6 @@ export default function CustomBlurDot({ cx, cy, fillColor }: Props) {
       }}
     />
   );
-}
+};
+
+export default CustomBlurDot;

--- a/src/pages/dashboardPage/views/@common/CustomCursor.tsx
+++ b/src/pages/dashboardPage/views/@common/CustomCursor.tsx
@@ -1,3 +1,8 @@
+/**
+ * @Description
+ * rechart 라이브러리를 활용한 그래프에서 사용되는 커서 UI입니다.
+ */
+
 type Props = {
   points?: { x: number; y: number }[];
   strokeColor?: string;
@@ -5,12 +10,12 @@ type Props = {
   y2?: number;
 };
 
-export default function CustomCursor({
+const CustomCursor = ({
   points,
   strokeColor = "#dadada",
   y1 = 60,
   y2 = 340,
-}: Props) {
+}: Props) => {
   const x = points?.[0]?.x;
   if (x === undefined) return null;
 
@@ -25,4 +30,6 @@ export default function CustomCursor({
       strokeDasharray="3 6"
     />
   );
-}
+};
+
+export default CustomCursor;

--- a/src/pages/dashboardPage/views/@common/CustomTooltip.tsx
+++ b/src/pages/dashboardPage/views/@common/CustomTooltip.tsx
@@ -1,6 +1,6 @@
 /**
  * @Description
- * rechart 라이브러리를 활용한 그래프에서 사용되는 툴팁입니다
+ * rechart 라이브러리를 활용한 그래프에서 사용되는 툴팁 UI입니다.
  */
 
 import { SegmentDatum } from "@/pages/dashboardPage/views/VisitorPieChart";
@@ -23,7 +23,7 @@ type Props = {
   unitPrefix?: string;
 };
 
-export default function CustomTooltip({
+const CustomTooltip = ({
   active,
   payload,
   label,
@@ -31,7 +31,7 @@ export default function CustomTooltip({
   unitPrefix,
   highlightColor,
   unitSuffix,
-}: Props) {
+}: Props) => {
   if (active && payload && payload.length) {
     const dynamicColor =
       highlightColor ??
@@ -61,4 +61,6 @@ export default function CustomTooltip({
     );
   }
   return null;
-}
+};
+
+export default CustomTooltip;

--- a/src/pages/dashboardPage/views/@common/DropdownFilter.tsx
+++ b/src/pages/dashboardPage/views/@common/DropdownFilter.tsx
@@ -1,19 +1,25 @@
+/**
+ * @Description
+ * Dropdown UI 입니다.
+ * - 대시보드 설문지 분석에 사용됩니다.
+ */
+
 import { useState, useRef, useEffect } from "react";
 import optionBar from "@/assets/webps/common/option-bar.webp";
 
-interface DropdownFilterProps<T extends string | number> {
+type Props<T extends string | number> = {
   value: T;
   options: readonly T[];
   onChange: (_value: T) => void;
   buttonGap?: string;
-}
+};
 
-export function DropdownFilter<T extends string | number>({
+const DropdownFilter = <T extends string | number>({
   value,
   options,
   onChange,
   buttonGap,
-}: DropdownFilterProps<T>) {
+}: Props<T>) => {
   const [open, setOpen] = useState(false);
   const dropdownRef = useRef<HTMLDivElement>(null);
 
@@ -71,4 +77,6 @@ export function DropdownFilter<T extends string | number>({
       )}
     </div>
   );
-}
+};
+
+export default DropdownFilter;

--- a/src/pages/dashboardPage/views/@common/NoDataComp.tsx
+++ b/src/pages/dashboardPage/views/@common/NoDataComp.tsx
@@ -1,6 +1,11 @@
+/**
+ * @Description
+ * GET 메서드로 받아온 data가 없을 때 사용되는 UI입니다.
+ */
+
 import sad from "@/assets/webps/dashboard/sad.webp";
 
-export default function NoDataComp() {
+const NoDataComp = () => {
   return (
     <div className="flex flex-col items-center justify-center w-full h-full">
       <div className="mb-4">
@@ -12,4 +17,6 @@ export default function NoDataComp() {
       <p className="text-[18px] text-gray07">아직 데이터가 없어요</p>
     </div>
   );
-}
+};
+
+export default NoDataComp;

--- a/src/pages/dashboardPage/views/@common/Title.tsx
+++ b/src/pages/dashboardPage/views/@common/Title.tsx
@@ -1,8 +1,13 @@
+/**
+ * @Description
+ * 대시보드에서 사용되는 Title UI입니다.
+ */
+
 type Props = {
   title: string;
 };
 
-export default function DashBoardTitle({ title }: Props) {
+const Title = ({ title }: Props) => {
   return (
     <div className="flex gap-[18px] items-start mb-10">
       <div className="flex gap-[6px] items-end">
@@ -13,4 +18,6 @@ export default function DashBoardTitle({ title }: Props) {
       <span className="text-gray10 font-bold text-[32px]">{title}</span>
     </div>
   );
-}
+};
+
+export default Title;

--- a/src/pages/dashboardPage/views/ConversionRateChart.tsx
+++ b/src/pages/dashboardPage/views/ConversionRateChart.tsx
@@ -1,5 +1,4 @@
-import CustomBlurDot from "@/components/common/CustomBlurDot";
-import CustomCursor from "@/components/common/CustomCursor";
+import CustomCursor from "@/pages/dashboardPage/views/@common/CustomCursor";
 import { GetConversionItemResponse } from "@/types/api/ApiResponseType";
 import { useCallback } from "react";
 import {
@@ -13,6 +12,7 @@ import {
   YAxis,
   TooltipProps,
 } from "recharts";
+import CustomBlurDot from "@/pages/dashboardPage/views/@common/CustomBlurDot";
 
 type Props = {
   data: GetConversionItemResponse[];

--- a/src/pages/dashboardPage/views/DashBoardConversionRate.tsx
+++ b/src/pages/dashboardPage/views/DashBoardConversionRate.tsx
@@ -1,8 +1,8 @@
-import NoDataComp from "@/components/common/NoDataComp";
+import NoDataComp from "@/pages/dashboardPage/views/@common/NoDataComp";
 import { useConversionApi } from "@/hooks/api/useDashboardApi";
 import { ConversionRateChart } from "@/pages/dashboardPage/views/ConversionRateChart";
-import DashBoardTitle from "@/pages/dashboardPage/views/DashBoardTitle";
-import Skeleton from "@/components/common/Skeleton";
+import Title from "@/pages/dashboardPage/views/@common/Title";
+import Skeleton from "@/components/ui/Skeleton";
 import QueryComponent from "@/components/common/QueryComponent";
 
 export default function DashBoardConversionRate() {
@@ -10,7 +10,7 @@ export default function DashBoardConversionRate() {
 
   return (
     <div className="flex flex-col" data-testid="dashboard-conversionRate">
-      <DashBoardTitle title="구매전환율" />
+      <Title title="구매전환율" />
       <div className="flex justify-between">
         {/* 하위 상품 TOP 6 */}
         <div className="relative w-[660px] h-[510px] bg-gray02 rounded-[50px] px-6 flex justify-center">

--- a/src/pages/dashboardPage/views/DashBoardCustomerTransaction.tsx
+++ b/src/pages/dashboardPage/views/DashBoardCustomerTransaction.tsx
@@ -1,8 +1,8 @@
 import { useAvgPurchaseApi } from "@/hooks/api/useDashboardApi";
-import { CountCard } from "@/pages/dashboardPage/views/CountCard";
-import DashBoardTitle from "@/pages/dashboardPage/views/DashBoardTitle";
-import NoDataComp from "@/components/common/NoDataComp";
-import Skeleton from "@/components/common/Skeleton";
+import CountCard from "@/pages/dashboardPage/views/@common/CountCard";
+import Title from "@/pages/dashboardPage/views/@common/Title";
+import NoDataComp from "@/pages/dashboardPage/views/@common/NoDataComp";
+import Skeleton from "@/components/ui/Skeleton";
 import QueryComponent from "@/components/common/QueryComponent";
 
 export default function DashBoardCustomerTransaction() {
@@ -10,7 +10,7 @@ export default function DashBoardCustomerTransaction() {
 
   return (
     <div className="w-[414px] flex-col" data-testid="dashboard-transaction">
-      <DashBoardTitle title="1인 평균 구매액" />
+      <Title title="1인 평균 구매액" />
       <div className="flex h-[394px] flex-col justify-between">
         {/* 팝업 기간 내 */}
         <QueryComponent

--- a/src/pages/dashboardPage/views/DashBoardQuestionnaire.tsx
+++ b/src/pages/dashboardPage/views/DashBoardQuestionnaire.tsx
@@ -1,14 +1,14 @@
 import { useState } from "react";
-import { DropdownFilter } from "@/components/common/DropdownFilter";
 import { Cell, Pie, PieChart, Tooltip, TooltipProps } from "recharts";
-import DashBoardTitle from "@/pages/dashboardPage/views/DashBoardTitle";
-import CustomTooltip from "@/components/common/CustomTooltip";
+import Title from "@/pages/dashboardPage/views/@common/Title";
+import CustomTooltip from "@/pages/dashboardPage/views/@common/CustomTooltip";
 import { useQuestionnaireApi } from "@/hooks/api/useDashboardApi";
 import { QuestionnaireResponse } from "@/types/api/ApiResponseType";
 import { Questions } from "@/constants/popUpCreate/Questions";
-import NoDataComp from "@/components/common/NoDataComp";
-import Skeleton from "@/components/common/Skeleton";
+import NoDataComp from "@/pages/dashboardPage/views/@common/NoDataComp";
+import Skeleton from "@/components/ui/Skeleton";
 import QueryComponent from "@/components/common/QueryComponent";
+import DropdownFilter from "@/pages/dashboardPage/views/@common/DropdownFilter";
 
 const options = ["1번 문항", "2번 문항", "3번 문항", "4번 문항"];
 const SIZE = 300;
@@ -75,7 +75,7 @@ export default function DashBoardQuestionnaire() {
       data-testid="dashboard-questionnaire-data-exist"
     >
       <div className="relative flex gap-[20px]">
-        <DashBoardTitle title="설문지 분석" />
+        <Title title="설문지 분석" />
         <div className="ml-2">
           <DropdownFilter
             value={selectedQuestion}

--- a/src/pages/dashboardPage/views/DashBoardReservation.tsx
+++ b/src/pages/dashboardPage/views/DashBoardReservation.tsx
@@ -1,14 +1,14 @@
-import DashBoardTitle from "@/pages/dashboardPage/views/DashBoardTitle";
+import Title from "@/pages/dashboardPage/views/@common/Title";
 import checkCalendar from "@/assets/webps/dashboard/check-calendar.webp";
-import { CountCard } from "@/pages/dashboardPage/views/CountCard";
 import ReservationByDayChart from "@/pages/dashboardPage/views/ReservationByDayChart";
 import {
   useTodayEntrantsApi,
   useTodayReservationsApi,
 } from "@/hooks/api/useDashboardApi";
-import Skeleton from "@/components/common/Skeleton";
-import NoDataComp from "@/components/common/NoDataComp";
+import Skeleton from "@/components/ui/Skeleton";
+import NoDataComp from "@/pages/dashboardPage/views/@common/NoDataComp";
 import QueryComponent from "@/components/common/QueryComponent";
+import CountCard from "@/pages/dashboardPage/views/@common/CountCard";
 
 export default function DashBoardReservation() {
   const entrants = useTodayEntrantsApi();
@@ -16,7 +16,7 @@ export default function DashBoardReservation() {
 
   return (
     <div className="w-[906px] flex-col" data-testid="dashboard-reservation">
-      <DashBoardTitle title="예약 분석" />
+      <Title title="예약 분석" />
       <div className="w-[906px] h-[394px] flex justify-between">
         {/* CountCard 2개 */}
         <div className="w-[314px] flex flex-col justify-between">

--- a/src/pages/dashboardPage/views/DashBoardVisitor.tsx
+++ b/src/pages/dashboardPage/views/DashBoardVisitor.tsx
@@ -1,10 +1,10 @@
-import DashBoardTitle from "@/pages/dashboardPage/views/DashBoardTitle";
+import Title from "@/pages/dashboardPage/views/@common/Title";
 import { mapGenderData, mapAgeData } from "@/utils/VisitorColorMapper";
 import VisitorPieChart from "@/pages/dashboardPage/views/VisitorPieChart";
 import { useVisitorStatsApi } from "@/hooks/api/useDashboardApi";
-import NoDataComp from "@/components/common/NoDataComp";
+import NoDataComp from "@/pages/dashboardPage/views/@common/NoDataComp";
 import QueryComponent from "@/components/common/QueryComponent";
-import Skeleton from "@/components/common/Skeleton";
+import Skeleton from "@/components/ui/Skeleton";
 
 export default function DashBoardVisitor() {
   const { gender, age, isLoading, isError } = useVisitorStatsApi();
@@ -12,7 +12,7 @@ export default function DashBoardVisitor() {
 
   return (
     <div className="flex flex-col w-[660px]" data-testid="dashboard-visitor">
-      <DashBoardTitle title="팝업스토어 방문자 분석" />
+      <Title title="팝업스토어 방문자 분석" />
 
       <div className="relative bg-gray02 w-[660px] h-[510px] rounded-[50px] pt-[92px] pb-[24px] px-[24px]">
         {/* 레이블 */}

--- a/src/pages/dashboardPage/views/ReservationByDayChart.tsx
+++ b/src/pages/dashboardPage/views/ReservationByDayChart.tsx
@@ -1,4 +1,4 @@
-import CustomTooltip from "@/components/common/CustomTooltip";
+import CustomTooltip from "@/pages/dashboardPage/views/@common/CustomTooltip";
 import { ReservationChartResponse } from "@/types/api/ApiResponseType";
 import { reservationColorMapper } from "@/utils/ReservationColorMapper";
 import {

--- a/src/pages/dashboardPage/views/VisitorPieChart.tsx
+++ b/src/pages/dashboardPage/views/VisitorPieChart.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { PieChart, Pie, Cell, Tooltip, TooltipProps } from "recharts";
-import CustomTooltip from "@/components/common/CustomTooltip";
+import CustomTooltip from "@/pages/dashboardPage/views/@common/CustomTooltip";
 
 export type SegmentDatum = {
   name: string;

--- a/src/pages/dashboardPage/views/bestItem/BestItemCardImage.tsx
+++ b/src/pages/dashboardPage/views/bestItem/BestItemCardImage.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import Skeleton from "@/components/common/Skeleton";
+import Skeleton from "@/components/ui/Skeleton";
 
 type BestItemCardImageProps = {
   src: string;

--- a/src/pages/dashboardPage/views/bestItem/index.tsx
+++ b/src/pages/dashboardPage/views/bestItem/index.tsx
@@ -1,9 +1,9 @@
 import { useBestItemsApi } from "@/hooks/api/useDashboardApi";
-import Skeleton from "@/components/common/Skeleton";
+import Skeleton from "@/components/ui/Skeleton";
 import QueryComponent from "@/components/common/QueryComponent";
-import NoDataComp from "@/components/common/NoDataComp";
+import NoDataComp from "@/pages/dashboardPage/views/@common/NoDataComp";
 import BestItemCard from "@/pages/dashboardPage/views/bestItem/BestItemCard";
-import DashBoardTitle from "@/pages/dashboardPage/views/DashBoardTitle";
+import Title from "@/pages/dashboardPage/views/@common/Title";
 
 const BestItem = () => {
   const { data: bestItemData, isLoading, isError } = useBestItemsApi();
@@ -12,7 +12,7 @@ const BestItem = () => {
     <div data-testid="dashboard-bestItems">
       {/* Title */}
       <div className="flex items-start gap-6">
-        <DashBoardTitle title="실시간 인기상품" />
+        <Title title="실시간 인기상품" />
       </div>
 
       {/* Top 3 카드 */}

--- a/src/pages/dashboardPage/views/congestion/CongestionChart.tsx
+++ b/src/pages/dashboardPage/views/congestion/CongestionChart.tsx
@@ -7,9 +7,9 @@ import {
   Tooltip,
   YAxis,
 } from "recharts";
-import CustomBlurDot from "@/components/common/CustomBlurDot";
-import CustomCursor from "@/components/common/CustomCursor";
-import CustomTooltip from "@/components/common/CustomTooltip";
+import CustomCursor from "@/pages/dashboardPage/views/@common/CustomCursor";
+import CustomTooltip from "@/pages/dashboardPage/views/@common/CustomTooltip";
+import CustomBlurDot from "@/pages/dashboardPage/views/@common/CustomBlurDot";
 
 type Props = {
   dayData: GetCongestionTimeValue[];

--- a/src/pages/dashboardPage/views/congestion/index.tsx
+++ b/src/pages/dashboardPage/views/congestion/index.tsx
@@ -2,10 +2,10 @@ import { useEffect, useState } from "react";
 import { Days } from "@/constants/dashboard/Days";
 import { useCongestionApi } from "@/hooks/api/useDashboardApi";
 import { DayOfWeek } from "@/types/CongestionType";
-import DashBoardTitle from "@/pages/dashboardPage/views/DashBoardTitle";
-import NoDataComp from "@/components/common/NoDataComp";
+import Title from "@/pages/dashboardPage/views/@common/Title";
+import NoDataComp from "@/pages/dashboardPage/views/@common/NoDataComp";
 import QueryComponent from "@/components/common/QueryComponent";
-import Skeleton from "@/components/common/Skeleton";
+import Skeleton from "@/components/ui/Skeleton";
 import CongestionChart from "@/pages/dashboardPage/views/congestion/CongestionChart";
 import CongestionDaySelector from "@/pages/dashboardPage/views/congestion/CongestionDaySelector";
 
@@ -23,7 +23,7 @@ const Congestion = () => {
 
   return (
     <div className="flex flex-col" data-testid="dashboard-congestion">
-      <DashBoardTitle title="혼잡도 분석" />
+      <Title title="혼잡도 분석" />
       <div className="relative w-[660px] h-[510px] bg-gray02 rounded-[50px] px-6">
         {/* 요일 버튼 */}
         <CongestionDaySelector

--- a/src/pages/itemCreatePage/ItemCreatePage.tsx
+++ b/src/pages/itemCreatePage/ItemCreatePage.tsx
@@ -1,4 +1,4 @@
-import CustomButton from "@/components/common/CustomButton";
+import CustomButton from "@/components/ui/CustomButton";
 import React, { useEffect, useState } from "react";
 
 import Modal from "@/components/common/Modal";

--- a/src/pages/itemCreatePage/views/ItemCreateInputs.tsx
+++ b/src/pages/itemCreatePage/views/ItemCreateInputs.tsx
@@ -1,7 +1,7 @@
-import CustomInput from "@/components/common/CustomInput";
+import CustomInput from "@/components/ui/CustomInput";
 import { useSelectedItemStore } from "@/stores/useSelectedItemStore";
 import React from "react";
-import NoImageComp from "@/components/common/NoImageComp";
+import NoImageComp from "@/components/ui/NoImageComp";
 
 type Props = {
   name: string;

--- a/src/pages/onBoardingPage/views/OnBoardingLogin.tsx
+++ b/src/pages/onBoardingPage/views/OnBoardingLogin.tsx
@@ -1,4 +1,4 @@
-import CustomInput from "@/components/common/CustomInput";
+import CustomInput from "@/components/ui/CustomInput";
 import Modal from "@/components/common/Modal";
 import React, { useState } from "react";
 import bin from "@/assets/webps/common/bin.webp";

--- a/src/pages/popUpCreatePage/views/PopUpInfoArea.tsx
+++ b/src/pages/popUpCreatePage/views/PopUpInfoArea.tsx
@@ -11,7 +11,7 @@ import { FormatDateTimeToString, FormatDateToString } from "@/utils/FormatDay";
 import { getTimeValue } from "@/utils/FormatTimestamp";
 import useClickOutside from "@/hooks/useClickOutside";
 import { addDays } from "date-fns";
-import NoImageComp from "@/components/common/NoImageComp";
+import NoImageComp from "@/components/ui/NoImageComp";
 
 type Props = {
   formData: PopUpWithChoicesRequest;

--- a/src/pages/popUpListPage/PopUpListPage.tsx
+++ b/src/pages/popUpListPage/PopUpListPage.tsx
@@ -14,7 +14,7 @@ import bin from "@/assets/webps/common/bin.webp";
 import check from "@/assets/webps/common/check.webp";
 import { usePopUpListReadApi } from "@/hooks/api/usePopUpListReadApi";
 import { usePopUpDeleteApi } from "@/hooks/api/usePopUpDeleteApi";
-import Loading from "@/components/common/Loading";
+import Loading from "@/components/ui/Loading";
 
 export default function PopUpListPage() {
   const { cards, isLoading } = usePopUpListReadApi();

--- a/src/utils/NotificationSocket.ts
+++ b/src/utils/NotificationSocket.ts
@@ -39,10 +39,3 @@ export const connectNotificationSocket = (
   });
   client.activate();
 };
-
-// 소켓 연결 해제
-export const disconnectNotificationSocket = () => {
-  if (client && client.connected) {
-    client.deactivate();
-  }
-};

--- a/src/utils/NotificationSocket.ts
+++ b/src/utils/NotificationSocket.ts
@@ -10,7 +10,7 @@ export const connectNotificationSocket = (
   managerId: number,
   popupId: number,
 ) => {
-  if (client?.active || client?.connected) return;
+  if (client?.connected) return;
 
   const baseURL = import.meta.env.VITE_API_URL;
   const token = useAuthStore.getState().accessToken;


### PR DESCRIPTION
## 🌱 관련 이슈

- [LCR-348]

---

## 📌 작업 내용 및 특이사항

- components 내부 구조 개선 및 분리하였습니다.
- 컴포넌트 선언 방식 const로 통일하였습니다.
- 기존 components/common 에 있던 컴포넌트들을 components/common과 components/ui에 적절하게 나누어 구조를 개선하였습니다.
- 대시보드 내부에서만 사용되는 공통 컴포넌트들은 pages/dashboardPage/views/@common 에 넣어 분리하였습니다.
- 공통적으로 사용되는 컴포넌트들에 @description 주석을 달았습니다.

---

## 📚 참고사항

<img width="335" alt="image" src="https://github.com/user-attachments/assets/fac3e300-b839-457b-b09c-7815aaf3cd00" />
<img width="260" alt="image" src="https://github.com/user-attachments/assets/b3ef39a1-a32e-4fc1-af83-f3230bdd783a" />
<img width="338" alt="image" src="https://github.com/user-attachments/assets/9e6df700-54e6-49c9-97c6-a087ad1ef2dc" />



[LCR-348]: https://lgcns-retail.atlassian.net/browse/LCR-348?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ