### PR TITLE
chore: E2E CI 수정

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -38,9 +38,8 @@ jobs:
 
   e2e-tests:
     runs-on: ubuntu-latest
-    if: contains(github.event.head_commit.message, '[e2e]')
+    if: github.event_name == 'pull_request' && contains(toJSON(github.event.commits.*.message), '[e2e]')
     needs: build-and-test
-
     steps:
       - uses: actions/checkout@v4
 

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -16,7 +16,8 @@ export default defineConfig({
   globalSetup: path.resolve("./tests/global-setup.ts"),
 
   use: {
-    baseURL: `${isCI ? process.env.VITE_DNS_URL : "http://localhost:3000"}`,
+    // baseURL: `${isCI ? process.env.VITE_DNS_URL : "http://localhost:3000"}`,
+    baseURL: "http://localhost:4173",
     trace: "on-first-retry",
     storageState: "tests/auth.json",
   },


### PR DESCRIPTION
## 🌱 관련 이슈

- [LCR-363]

---

## 📌 작업 내용 및 특이사항

- 기존에는 Head Commit에만 [e2e] 플래그 존재여부를 파악하여 CI가 동작하는 문제가 있었습니다.
- 수정한 CI는 모든 커밋 로그를 확인하여 [e2e] 플래그가 하나라도 있다면 E2E CI가 동작하게 됩니다.
- 또한, E2E는 PR이 생성되어있어야만 동작하는 조건을 추가했습니다

---

## 📚 참고사항
```yaml
e2e-tests:
    runs-on: ubuntu-latest
    if: github.event_name == 'pull_request' && contains(toJSON(github.event.commits.*.message), '[e2e]')
```

[LCR-363]: https://lgcns-retail.atlassian.net/browse/LCR-363?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ